### PR TITLE
feat(netcdf): read any dimension's coordinates, and select by label or nearest

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -5,51 +5,51 @@
 
 ### BREAKING CHANGE
 
-- get_variable and variables[name] return a                                                             
-  LabeledArray instead of a gdal.MDArray for a variable with no raster                                                   
-  plane. Replace ReadAsArray() with .values, GetDimensions() with                                                        
-  .dims / .shape, GetUnit() with .unit, GetNoDataValueAsDouble() with                                                    
-  .no_data_value and GetScale() / GetOffset() with .scale / .offset.                                                     
-  crop_variable, reproject_variable, resample_variable,                                                                  
-  plot(variable=) and open_mfdataset(variable=) raise ValueError for                                                     
-  such a variable instead of AttributeError. A compound variable with a                                                  
-  string field raises ValueError, since GDAL's Python bindings cannot                                                    
-  read it. The array behind variables[name] is read-only; take .copy()                                                   
+- get_variable and variables[name] return a  
+  LabeledArray instead of a gdal.MDArray for a variable with no raster  
+  plane. Replace ReadAsArray() with .values, GetDimensions() with  
+  .dims / .shape, GetUnit() with .unit, GetNoDataValueAsDouble() with  
+  .no_data_value and GetScale() / GetOffset() with .scale / .offset.  
+  crop_variable, reproject_variable, resample_variable,  
+  plot(variable=) and open_mfdataset(variable=) raise ValueError for  
+  such a variable instead of AttributeError. A compound variable with a  
+  string field raises ValueError, since GDAL's Python bindings cannot  
+  read it. The array behind variables[name] is read-only; take .copy()  
   to modify it
 
 ### Fix
 
 - **dataset,netcdf**: unpack CF-packed data by default, on one keyword (#1130)
 - **netcdf**: materialise a non-raster variable instead of leaking a gdal.MDArray (#1131)
-- **netcdf**: materialise a non-raster variable instead of leaking a gdal.MDArray                                      
-                                                                                                                         
-  get_variable returned the raw gdal.MDArray whenever GDAL could not                                                     
-  expose a variable as a raster plane -- a 1-D array, or a string or                                                     
-  compound one. That handle has none of pyramids' API, and its Read()                                                    
-  returns an undecoded buffer for numeric data, so the only route to                                                     
-  the values was ReadAsArray(): raw osgeo in a package meant to hide it.                                                 
-                                                                                                                         
-  - return a LabeledArray, carrying the values with their dims, shape,                                                   
-    name, unit, no_data_value, scale, offset and attributes                                                              
-  - read each dtype class with the reader it needs: strings via Read()                                                   
-    into object (a NULL entry stays None), numeric and compound via                                                      
-    ReadAsArray(); build an empty array for a zero-length extent, and                                                    
-    keep a 64-bit integer fill value exact                                                                               
-  - correct the return annotation to NetCDF | LabeledArray and route the                                                 
-    raster-only callers through _require_raster_variable, which refuses                                                  
-    a non-raster variable by name instead of raising AttributeError                                                      
-  - decide raster-ness from the array's declaration, not by reading it,                                                  
-    so a CRS lookup no longer materialises a large non-raster array                                                      
-  - carry a string or compound array on (y, x) as an auxiliary rather                                                    
-    than refusing the whole container crop, to_crs or reduce                                                             
-  - drop an auxiliary the carry cannot write instead of failing the                                                      
-    operation or leaving an empty array behind, and keep a string                                                        
-    auxiliary's unit and spatial reference                                                                               
-  - reuse the resolved values in read_array, reading once rather than                                                    
-    twice, and freeze the entry the variables cache shares                                                               
-  - document the change in the migration guide, the concepts page and                                                    
-    the NetCDF reference                                                                                                 
-                                                                                                                         
+- **netcdf**: materialise a non-raster variable instead of leaking a gdal.MDArray  
+
+  get_variable returned the raw gdal.MDArray whenever GDAL could not  
+  expose a variable as a raster plane -- a 1-D array, or a string or  
+  compound one. That handle has none of pyramids' API, and its Read()  
+  returns an undecoded buffer for numeric data, so the only route to  
+  the values was ReadAsArray(): raw osgeo in a package meant to hide it.  
+
+  - return a LabeledArray, carrying the values with their dims, shape,  
+    name, unit, no_data_value, scale, offset and attributes  
+  - read each dtype class with the reader it needs: strings via Read()  
+    into object (a NULL entry stays None), numeric and compound via  
+    ReadAsArray(); build an empty array for a zero-length extent, and  
+    keep a 64-bit integer fill value exact  
+  - correct the return annotation to NetCDF | LabeledArray and route the  
+    raster-only callers through _require_raster_variable, which refuses  
+    a non-raster variable by name instead of raising AttributeError  
+  - decide raster-ness from the array's declaration, not by reading it,  
+    so a CRS lookup no longer materialises a large non-raster array  
+  - carry a string or compound array on (y, x) as an auxiliary rather  
+    than refusing the whole container crop, to_crs or reduce  
+  - drop an auxiliary the carry cannot write instead of failing the  
+    operation or leaving an empty array behind, and keep a string  
+    auxiliary's unit and spatial reference  
+  - reuse the resolved values in read_array, reading once rather than  
+    twice, and freeze the entry the variables cache shares  
+  - document the change in the migration guide, the concepts page and  
+    the NetCDF reference  
+
   Closes #1126
 
 ## 0.61.0 (2026-09-09)

--- a/docs/reference/netcdf/index.md
+++ b/docs/reference/netcdf/index.md
@@ -95,9 +95,8 @@ presents rasters north-up, so on a south-to-north file `get_dimension_values("la
 `read_array()`'s row 0 is the northernmost row. Use `get_y_lat_dimension_array` when you want to index
 rows; use this when you want to know what the file holds.
 
-They match what `sel` selects on. A CF time axis is stored as
-raw offsets; `get_time_variable()` decodes the same axis to date strings, and `sel` accepts either
-vocabulary:
+Whatever the axis, these are the values `sel` selects on. A CF time axis is stored as raw offsets;
+`get_time_variable()` decodes the same axis to date strings, and `sel` accepts either vocabulary:
 
 ```python
 var = nc.get_variable("rhum")
@@ -129,7 +128,9 @@ pinned = var.sel(level=900, method="nearest")
 pinned.get_dimension_values("level")   # array([925.])
 ```
 
-Both reach `NetCDF.plot` through `Selectors(..., method="nearest")`.
+Both vocabularies reach `NetCDF.plot` through `Selectors`; `method="nearest"` is the extra knob
+for the numeric one, and applies only to the dims whose selector is numeric, so a date label on
+another dim stays exact in the same call.
 
 ## Lazy / Dask reads
 

--- a/docs/reference/netcdf/index.md
+++ b/docs/reference/netcdf/index.md
@@ -98,9 +98,19 @@ var = nc.get_variable("rhum")
 
 var.sel(level=850)                            # exact stored value
 var.sel(level=900, method="nearest")          # snap to the closest level (925)
-var.sel(time="2024-01-01 12:00:00")           # the label get_time_variable() reports
+var.sel(time="2024-01-01 12:00:00")           # a full-precision label pins one step
 var.sel(time="2024-01")                       # a partial label takes the whole month
 var.sel(time=slice("2024-01-01", "2024-01-03"))
+```
+
+A label names a **period**, not an instant, so its precision decides how much it selects. That matters
+when the label comes from `get_time_variable()`: its default `time_format` is `"%Y-%m-%d"`, so feeding
+one of those labels straight back keeps every step of that day. Ask for the finer format when you want
+one step:
+
+```python
+nc.get_time_variable("time")[1]                       # '2024-01-01'  -> the whole day
+nc.get_time_variable("time", "%Y-%m-%d %H:%M:%S")[1]  # '2024-01-01 06:00:00'  -> one step
 ```
 
 `method="nearest"` snaps each requested value to the closest coordinate on its axis, so a caller can

--- a/docs/reference/netcdf/index.md
+++ b/docs/reference/netcdf/index.md
@@ -77,6 +77,44 @@ classDiagram
     note for Variable "band_count >= 1 · one raster variable"
 ```
 
+## Dimension coordinates and selection
+
+`dimension_names` / `dimension_sizes` name a cube's axes; `get_dimension_values(name)` reads the
+coordinate values of any one of them — the vertical, ensemble or other non-spatial axis included,
+which previously had no native accessor:
+
+```python
+nc = NetCDF.read_file("rhum.nc")
+nc.dimension_sizes                    # {'lon': 72, 'lat': 37, 'level': 4, 'time': 12}
+nc.get_dimension_values("level")      # array([1000.,  925.,  850.,  700.])
+```
+
+The values are the **stored** ones, so they match what `sel` selects on. A CF time axis is stored as
+raw offsets; `get_time_variable()` decodes the same axis to date strings, and `sel` accepts either
+vocabulary:
+
+```python
+var = nc.get_variable("rhum")
+
+var.sel(level=850)                            # exact stored value
+var.sel(level=900, method="nearest")          # snap to the closest level (925)
+var.sel(time="2024-01-01 12:00:00")           # the label get_time_variable() reports
+var.sel(time="2024-01")                       # a partial label takes the whole month
+var.sel(time=slice("2024-01-01", "2024-01-03"))
+```
+
+`method="nearest"` snaps each requested value to the closest coordinate on its axis, so a caller can
+ask for "the level nearest 100 m" without knowing the axis values up front. It needs a numeric
+selector — a slice has no nearest value, and a date label already names a period. Read back the
+coordinate it chose with `get_dimension_values` on the result:
+
+```python
+pinned = var.sel(level=900, method="nearest")
+pinned.get_dimension_values("level")   # array([925.])
+```
+
+Both reach `NetCDF.plot` through `Selectors(..., method="nearest")`.
+
 ## Lazy / Dask reads
 
 Every NetCDF entry point has a lazy variant that keeps memory bounded

--- a/docs/reference/netcdf/index.md
+++ b/docs/reference/netcdf/index.md
@@ -89,7 +89,13 @@ nc.dimension_sizes                    # {'lon': 72, 'lat': 37, 'level': 4, 'time
 nc.get_dimension_values("level")      # array([1000.,  925.,  850.,  700.])
 ```
 
-The values are the **stored** ones, so they match what `sel` selects on. A CF time axis is stored as
+The values are the **stored** ones — the same array `to_xarray().coords` reports, without needing the
+optional xarray extra. For a **spatial** axis that is not necessarily the raster's order: pyramids
+presents rasters north-up, so on a south-to-north file `get_dimension_values("lat")` ascends while
+`read_array()`'s row 0 is the northernmost row. Use `get_y_lat_dimension_array` when you want to index
+rows; use this when you want to know what the file holds.
+
+They match what `sel` selects on. A CF time axis is stored as
 raw offsets; `get_time_variable()` decodes the same axis to date strings, and `sel` accepts either
 vocabulary:
 

--- a/docs/reference/netcdf/plot.md
+++ b/docs/reference/netcdf/plot.md
@@ -41,7 +41,7 @@ from pyramids.netcdf import NetCDF, Selectors, CoordinateSpec, FacetSpec
 nc = NetCDF.read_file("era5.nc")
 
 # pick a variable, select along non-spatial dims, labeled-array-style colour kwargs
-nc.plot("t2m", selectors=Selectors(time="2020-01-01", level=850),
+nc.plot("t2m", selectors=Selectors(time="2020-01-01 12:00:00", level=850),
         cmap="coolwarm", robust=True)
 
 # curvilinear (WRF) grid -> pcolormesh, faceted over time
@@ -60,7 +60,7 @@ animate=None, chunks=None, basemap=None, exclude_value=None, title=None, **kwarg
 | Parameter   | Type                                | Notes |
 |-------------|-------------------------------------|-------|
 | `variable`  | `str`, optional                     | Variable to plot; defaults to the dataset's single / active variable. |
-| `selectors` | `Selectors`, optional               | Slice along non-spatial dims — `time=`, `level=`, `member=`, `sel=`, `isel=`, `method=`. |
+| `selectors` | `Selectors`, optional | Pin non-spatial dims: `time=`, `level=`, `member=`, `sel=`, `isel=`, `method=` |
 | `facet`     | `FacetSpec`, optional               | Small-multiples grid — `col=`, `row=`, `col_wrap=`. |
 | `axes`      | `CoordinateSpec`, optional          | Curvilinear coords / dimension names — `coords=(x_2d, y_2d)` (-> `pcolormesh`), `x_dim=`, `y_dim=`. Auto-detected from CF / WRF / ROMS / NEMO when omitted. |
 | `kind`      | `str`, optional                     | `"auto"`, `"imshow"`, `"pcolormesh"`, `"contour"`, `"contourf"`. |

--- a/docs/reference/netcdf/plot.md
+++ b/docs/reference/netcdf/plot.md
@@ -60,7 +60,7 @@ animate=None, chunks=None, basemap=None, exclude_value=None, title=None, **kwarg
 | Parameter   | Type                                | Notes |
 |-------------|-------------------------------------|-------|
 | `variable`  | `str`, optional                     | Variable to plot; defaults to the dataset's single / active variable. |
-| `selectors` | `Selectors`, optional               | Slice along non-spatial dimensions — `time=`, `level=`, `member=`, plus generic `sel=` / `isel=`. |
+| `selectors` | `Selectors`, optional               | Slice along non-spatial dims — `time=`, `level=`, `member=`, `sel=`, `isel=`, `method=`. |
 | `facet`     | `FacetSpec`, optional               | Small-multiples grid — `col=`, `row=`, `col_wrap=`. |
 | `axes`      | `CoordinateSpec`, optional          | Curvilinear coords / dimension names — `coords=(x_2d, y_2d)` (-> `pcolormesh`), `x_dim=`, `y_dim=`. Auto-detected from CF / WRF / ROMS / NEMO when omitted. |
 | `kind`      | `str`, optional                     | `"auto"`, `"imshow"`, `"pcolormesh"`, `"contour"`, `"contourf"`. |
@@ -68,6 +68,12 @@ animate=None, chunks=None, basemap=None, exclude_value=None, title=None, **kwarg
 | `chunks`    | `dict`, optional                    | Dask chunking — switches to a lazy read; only the rendered slice / frame is materialised. Requires the `[lazy]` extra. |
 | `basemap`   | `bool` or `str`, optional           | Overlay a web-tile basemap (provider name as a string, e.g. `"CartoDB.Positron"`). Requires the `[viz]` extra. |
 | `**kwargs`  |                                     | Colour, exactly as `Dataset.plot`: loose kwargs (`cmap`, `vmin`, `vmax`, `robust`, `center`, `extend`, `levels`, `norm`) + cleopatra bags `colorbar=` (`ColorBar(...)` / `False`), `color=`, `contour=`, `cells=`, `data_style=`; plus `ax`, `figsize`. |
+
+`Selectors` forwards its selectors to `NetCDF.sel`, so they take the same two vocabularies: a `time=`
+selector may be the stored CF offset or the date label `get_time_variable()` reports, whole
+(`"2020-01-01 12:00:00"`) or partial (`"2020-01"` names the whole month), and `method="nearest"`
+snaps each numeric selector to the closest coordinate on its axis instead of requiring an exact one.
+See [Dimension coordinates and selection](index.md#dimension-coordinates-and-selection).
 
 The GeoTIFF-only kwargs `band`, `rgb`, `surface_reflectance`, `cutoff`, `percentile`, `overview`,
 and `overview_index` are **not** accepted on `NetCDF.plot` — passing any of them raises `TypeError`

--- a/docs/reference/netcdf/plot.md
+++ b/docs/reference/netcdf/plot.md
@@ -70,9 +70,12 @@ animate=None, chunks=None, basemap=None, exclude_value=None, title=None, **kwarg
 | `**kwargs`  |                                     | Colour, exactly as `Dataset.plot`: loose kwargs (`cmap`, `vmin`, `vmax`, `robust`, `center`, `extend`, `levels`, `norm`) + cleopatra bags `colorbar=` (`ColorBar(...)` / `False`), `color=`, `contour=`, `cells=`, `data_style=`; plus `ax`, `figsize`. |
 
 `Selectors` forwards its selectors to `NetCDF.sel`, so they take the same two vocabularies: a `time=`
-selector may be the stored CF offset or the date label `get_time_variable()` reports, whole
-(`"2020-01-01 12:00:00"`) or partial (`"2020-01"` names the whole month), and `method="nearest"`
-snaps each numeric selector to the closest coordinate on its axis instead of requiring an exact one.
+selector may be the stored CF offset or a decoded date label. A label names a period, so its precision
+decides how much it pins — `"2020-01-01 12:00:00"` is one step, `"2020-01-01"` the whole day, `"2020-01"`
+the whole month. `get_time_variable()` reports date-only labels unless asked for a finer
+`time_format`, so pass `"%Y-%m-%d %H:%M:%S"` when you need a label that pins a single slice.
+`method="nearest"` snaps each **numeric** selector to the closest coordinate on its axis; label
+selectors on other dims are unaffected and stay exact.
 See [Dimension coordinates and selection](index.md#dimension-coordinates-and-selection).
 
 The GeoTIFF-only kwargs `band`, `rgb`, `surface_reflectance`, `cutoff`, `percentile`, `overview`,

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import math
 import numbers
-import re
 from collections.abc import Callable
 from typing import Any
 
@@ -41,10 +40,9 @@ _UPPER_TEMPLATE = "9999-12-31 23:59:59"
 
 # A label is recognised by its *shape*, not merely its length: "control" is seven
 # characters like "2024-01" but is an ensemble member's name, not a date, and belongs on
-# the stored-value path.
-_LABEL_PATTERN = re.compile(
-    r"\d{4}(?:-\d{2}(?:-\d{2}(?:[ ]\d{2}(?::\d{2}(?::\d{2})?)?)?)?)?\Z"
-)
+# the stored-value path. Each position either holds a digit (written "0" here) or the
+# literal separator, so a prefix of this template describes every supported precision.
+_LABEL_SHAPE = "0000-00-00 00:00:00"
 
 _PRECISION_FORMATS = {
     4: "%Y",
@@ -54,6 +52,21 @@ _PRECISION_FORMATS = {
     16: "%Y-%m-%d %H:%M",
     19: FULL_FORMAT,
 }
+
+
+def _has_label_shape(label: str) -> bool:
+    """Return whether ``label`` reads as a date prefix — digits and separators in place.
+
+    Cheaper and plainer than a nested-optional regular expression, and it says the rule
+    directly: every supported precision is a prefix of ``YYYY-MM-DD HH:MM:SS``, cut at
+    one of the boundaries :data:`_PRECISION_FORMATS` names. The length gate is what keeps
+    a bare ``"850"`` from reading as a three-digit year.
+    """
+    template = _LABEL_SHAPE[: len(label)]
+    return len(label) in _PRECISION_FORMATS and all(
+        character.isdigit() if expected == "0" else character == expected
+        for character, expected in zip(label, template)
+    )
 
 
 def summarise_values(values: list, full_below: int = 21, edge: int = 3) -> str:
@@ -174,7 +187,7 @@ def label_format(text: str) -> str:
         pad_label: extends a partial label to the edge of the period it names.
     """
     label = normalise_label(text)
-    fmt = _PRECISION_FORMATS.get(len(label)) if _LABEL_PATTERN.match(label) else None
+    fmt = _PRECISION_FORMATS.get(len(label)) if _has_label_shape(label) else None
     if fmt is None:
         raise ValueError(
             f"{text!r} is not a supported date label. Write one of "
@@ -394,7 +407,7 @@ def probe_format(selector: Any) -> str | None:
     label = first_label(selector)
     if label is None:
         fmt: str | None = None
-    elif not _LABEL_PATTERN.match(normalise_label(label)):
+    elif not _has_label_shape(normalise_label(label)):
         # The shape test governs a slice too: `slice("control", "x")` is a range of
         # stored values that happen to be strings, not a date range, and routing it
         # through the label path would fail inside `pad_label` instead.

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -351,17 +351,17 @@ def probe_format(selector: Any) -> str | None:
             ```
     """
     label = first_label(selector)
-    if isinstance(selector, slice) and label is not None:
-        fmt: str | None = FULL_FORMAT
-    elif label is None:
+    if label is None:
+        fmt: str | None = None
+    elif not _LABEL_PATTERN.match(normalise_label(label)):
+        # The shape test governs a slice too: `slice("control", "x")` is a range of
+        # stored values that happen to be strings, not a date range, and routing it
+        # through the label path would fail inside `pad_label` instead.
         fmt = None
+    elif isinstance(selector, slice):
+        fmt = FULL_FORMAT
     else:
-        normalised = normalise_label(label)
-        fmt = (
-            _PRECISION_FORMATS.get(len(normalised))
-            if _LABEL_PATTERN.match(normalised)
-            else None
-        )
+        fmt = _PRECISION_FORMATS.get(len(normalise_label(label)))
     return fmt
 
 

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -366,6 +366,11 @@ def _label_slice_indices(
     one covers its whole period, and swapped when the axis runs newest-first.
     """
     labels = decode(FULL_FORMAT)
+    if not labels:
+        # An axis with nothing decoded has no label to fall inside the range. The engine
+        # guards this before calling, but the primitive is shared and doctested on its
+        # own, so it must not die in `min()` on an empty axis.
+        return []
     start = None if selector.start is None else normalise_label(selector.start)
     stop = None if selector.stop is None else normalise_label(selector.stop)
     # Order the bounds *before* padding: which end a partial label extends to depends on

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -56,6 +56,47 @@ _PRECISION_FORMATS = {
 }
 
 
+def summarise_values(values: list, full_below: int = 21, edge: int = 3) -> str:
+    """Render an axis' values for an error message, elided in the middle when long.
+
+    A typo'd selector is a routine mistake, and on a 128k-step time axis interpolating
+    every decoded label makes the exception string megabytes of timestamps. The threshold
+    is generous on purpose: on a monthly or hourly axis the values themselves are what a
+    caller needs to fix the typo, so only a genuinely long axis is cut.
+
+    Args:
+        values: The values the selector was matched against.
+        full_below: List everything while there are fewer than this many. Defaults to 21.
+        edge: How many to show at each end once elided. Defaults to 3.
+
+    Returns:
+        str: The full list when it is short, else ``[first, ..., last] (N values)``.
+
+    Examples:
+        - A short axis is listed in full:
+            ```python
+            >>> from pyramids.netcdf._label_select import summarise_values
+            >>> summarise_values([1000.0, 850.0, 500.0])
+            '[1000.0, 850.0, 500.0]'
+
+            ```
+        - A long one keeps both ends and says how many there were:
+            ```python
+            >>> from pyramids.netcdf._label_select import summarise_values
+            >>> summarise_values(list(range(100)))
+            '[0, 1, 2, ..., 97, 98, 99] (100 values)'
+
+            ```
+    """
+    if len(values) < full_below:
+        rendered = repr(values)
+    else:
+        head = ", ".join(repr(value) for value in values[:edge])
+        tail = ", ".join(repr(value) for value in values[-edge:])
+        rendered = f"[{head}, ..., {tail}] ({len(values)} values)"
+    return rendered
+
+
 def normalise_label(text: str) -> str:
     """Normalise a date label to the ``YYYY-MM-DD HH:MM:SS`` spelling this module matches on.
 
@@ -526,7 +567,8 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
         )
     if not all(_is_number(coord) for coord in coords):
         raise ValueError(
-            f"method='nearest' needs a numeric coordinate axis, got {coords!r}."
+            "method='nearest' needs a numeric coordinate axis, got "
+            f"{summarise_values(coords)}."
         )
     # A `_FillValue` in a coordinate axis arrives as NaN, which compares false against
     # everything — so a plain `min` over the distances would hand back whichever slot it
@@ -539,7 +581,8 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
     ]
     if not candidates:
         raise ValueError(
-            f"method='nearest' found no finite coordinate to snap to on this axis: {coords!r}."
+            "method='nearest' found no finite coordinate to snap to on this axis: "
+            f"{summarise_values(coords)}."
         )
     found: set[int] = set()
     for value in wanted:

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -20,6 +20,7 @@ Two concerns live here:
 
 from __future__ import annotations
 
+import math
 import numbers
 from collections.abc import Callable
 from typing import Any
@@ -358,12 +359,14 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
         selector: A number, or a list of numbers (each snapped independently).
 
     Returns:
-        list[int]: Ascending indices of the snapped coordinates — one per requested
-            value, deduplicated when two requests snap to the same coordinate.
+        list[int]: Indices of the snapped coordinates, in **axis** order rather than
+            request order, deduplicated when two requests snap to the same coordinate.
+            Non-finite coordinates (a ``_FillValue`` in the axis) are never snapped to.
 
     Raises:
-        ValueError: The selector is a :class:`slice` (a range has no nearest value), or
-            either the selector or the axis is not numeric.
+        ValueError: The selector is a :class:`slice` (a range has no nearest value), the
+            selector is not a finite number, the axis is not numeric, or the axis holds
+            no finite coordinate to snap to.
 
     Examples:
         - A value between two levels snaps to the closer one:
@@ -403,12 +406,29 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
         raise ValueError(
             f"method='nearest' needs numeric selector values, got {selector!r}."
         )
-    if not all(_is_number(value) for value in coords):
+    if not all(math.isfinite(value) for value in wanted):
+        raise ValueError(
+            f"method='nearest' needs finite selector values, got {selector!r}."
+        )
+    if not all(_is_number(coord) for coord in coords):
         raise ValueError(
             f"method='nearest' needs a numeric coordinate axis, got {coords!r}."
         )
+    # A `_FillValue` in a coordinate axis arrives as NaN, which compares false against
+    # everything — so a plain `min` over the distances would hand back whichever slot it
+    # was seeded with, silently snapping to the fill value's plane. Scan only the real
+    # coordinates, and say so when there are none.
+    candidates = [
+        (position, coord)
+        for position, coord in enumerate(coords)
+        if math.isfinite(coord)
+    ]
+    if not candidates:
+        raise ValueError(
+            f"method='nearest' found no finite coordinate to snap to on this axis: {coords!r}."
+        )
     found: set[int] = set()
     for value in wanted:
-        distances = [abs(coord - value) for coord in coords]
-        found.add(distances.index(min(distances)))
+        distances = [abs(coord - value) for _, coord in candidates]
+        found.add(candidates[distances.index(min(distances))][0])
     return sorted(found)

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -354,6 +354,10 @@ def _is_number(value: Any) -> bool:
 def nearest_indices(coords: list, selector: Any) -> list[int]:
     """Snap a numeric selector to the closest coordinate(s) on an axis.
 
+    A request exactly between two coordinates resolves to the **smaller** one, whichever
+    end of the axis it is stored at, so the same physical request answers the same way on
+    an ascending and a descending axis.
+
     Args:
         coords: The axis' stored coordinate values.
         selector: A number, or a list of numbers (each snapped independently).
@@ -429,6 +433,12 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
         )
     found: set[int] = set()
     for value in wanted:
-        distances = [abs(coord - value) for _, coord in candidates]
-        found.add(candidates[distances.index(min(distances))][0])
+        # Rank by (distance, coordinate) rather than by position, so a request that falls
+        # exactly between two coordinates resolves to the same one whether the file
+        # stores the axis ascending or descending — the direction-agnostic rule `sel`'s
+        # slice path already advertises. The smaller coordinate wins a tie.
+        _, _, position = min(
+            (abs(coord - value), coord, index) for index, coord in candidates
+        )
+        found.add(position)
     return sorted(found)

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -444,7 +444,8 @@ def label_indices(decode: Callable[[str], list[str]], selector: Any) -> list[int
     Args:
         decode: Callable turning a strftime format into the axis' decoded labels, one
             per coordinate value (``nc._decode_time_labels`` bound to the dimension).
-        selector: A label, a list of labels, or a :class:`slice` of labels.
+        selector: A label, a list of labels, or a :class:`slice` of labels. A slice's
+            ``step`` is ignored, matching the stored-value path.
 
     Returns:
         list[int]: Ascending indices of the matching coordinates; empty when none match.

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -125,7 +125,7 @@ def label_format(text: str) -> str:
             >>> label_format("2024-01-01 06:0")  # doctest: +ELLIPSIS
             Traceback (most recent call last):
                 ...
-            ValueError: '2024-01-01 06:0' is not a supported date label. Supported...
+            ValueError: '2024-01-01 06:0' is not a supported date label. Write one of...
 
             ```
 
@@ -135,9 +135,10 @@ def label_format(text: str) -> str:
     label = normalise_label(text)
     fmt = _PRECISION_FORMATS.get(len(label)) if _LABEL_PATTERN.match(label) else None
     if fmt is None:
-        supported = ", ".join(sorted(_PRECISION_FORMATS.values(), key=len))
         raise ValueError(
-            f"{text!r} is not a supported date label. Supported precisions: {supported}."
+            f"{text!r} is not a supported date label. Write one of "
+            "'2024', '2024-01', '2024-01-01', '2024-01-01 06', '2024-01-01 06:00', "
+            "'2024-01-01 06:00:00'."
         )
     return fmt
 
@@ -175,7 +176,7 @@ def pad_label(text: str, *, upper: bool) -> str:
             ```
     """
     label = normalise_label(text)
-    label_format(label)
+    label_format(label)  # validates the precision; the format itself is not needed here
     template = _UPPER_TEMPLATE if upper else _LOWER_TEMPLATE
     return label + template[len(label) :]
 

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -1,0 +1,328 @@
+"""Label and nearest-value matching primitives for :meth:`NetCDF.sel`.
+
+Pure helpers — no pyramids imports — shared by the eager selection engine
+(:mod:`pyramids.netcdf.engines.selection`) and the plot engine's flat-band index
+(:mod:`pyramids.netcdf._plot`), so the two paths resolve a selector identically.
+
+Two concerns live here:
+
+* **Date-label selection.** A CF time axis is *stored* as raw offsets
+  (``[0.0, 6.0, 12.0, 18.0]`` for ``hours since 2024-01-01``), while every accessor
+  that decodes it — :meth:`NetCDF.get_time_variable` — hands back date strings. These
+  helpers turn a date label, whole or partial (``"2024"`` through
+  ``"2024-01-01 18:00:00"``), into the strftime format that decodes the axis at the
+  *same* precision, so matching is a plain string comparison and a partial label
+  matches every step inside the period it names.
+* **Nearest-value selection.** ``method="nearest"`` snaps a numeric selector to the
+  closest coordinate on the axis, which is how a caller asks for "the level nearest
+  100 m" without knowing the axis values up front.
+"""
+
+from __future__ import annotations
+
+import numbers
+from collections.abc import Callable
+from typing import Any
+
+FULL_FORMAT = "%Y-%m-%d %H:%M:%S"
+"""strftime format of a fully-qualified date label — the widest precision supported."""
+
+_LOWER_TEMPLATE = "0001-01-01 00:00:00"
+_UPPER_TEMPLATE = "9999-12-31 23:59:59"
+
+_PRECISION_FORMATS = {
+    4: "%Y",
+    7: "%Y-%m",
+    10: "%Y-%m-%d",
+    13: "%Y-%m-%d %H",
+    16: "%Y-%m-%d %H:%M",
+    19: FULL_FORMAT,
+}
+
+
+def normalise_label(text: str) -> str:
+    """Normalise a date label to the ``YYYY-MM-DD HH:MM:SS`` spelling this module matches on.
+
+    Accepts the ISO ``T`` separator and a trailing ``Z``, so a label copied out of an
+    ISO timestamp resolves the same as the space-separated form the CF decoders emit.
+
+    Args:
+        text: A whole or partial date label, e.g. ``"2024-01-01T06:00:00Z"``.
+
+    Returns:
+        str: The same instant spelled with a space separator and no zone suffix.
+
+    Examples:
+        - The ISO ``T`` separator and trailing ``Z`` are normalised away:
+            ```python
+            >>> from pyramids.netcdf._label_select import normalise_label
+            >>> normalise_label("2024-01-01T06:00:00Z")
+            '2024-01-01 06:00:00'
+
+            ```
+        - A partial label passes through unchanged apart from surrounding space:
+            ```python
+            >>> from pyramids.netcdf._label_select import normalise_label
+            >>> normalise_label("  2024-01 ")
+            '2024-01'
+
+            ```
+    """
+    label = text.strip()
+    if label.endswith("Z"):
+        label = label[:-1].strip()
+    if len(label) > 10 and label[10] == "T":
+        label = f"{label[:10]} {label[11:]}"
+    return label
+
+
+def label_format(text: str) -> str:
+    """Return the strftime format that decodes an axis at ``text``'s precision.
+
+    Args:
+        text: A whole or partial date label (normalised or not).
+
+    Returns:
+        str: The matching strftime format, e.g. ``"%Y-%m"`` for ``"2024-01"``.
+
+    Raises:
+        ValueError: The label is not one of the supported precisions.
+
+    Examples:
+        - A date-only label decodes the axis to dates:
+            ```python
+            >>> from pyramids.netcdf._label_select import label_format
+            >>> label_format("2024-01-01")
+            '%Y-%m-%d'
+
+            ```
+        - A year-only label decodes the axis to years:
+            ```python
+            >>> from pyramids.netcdf._label_select import label_format
+            >>> label_format("2024")
+            '%Y'
+
+            ```
+    """
+    label = normalise_label(text)
+    fmt = _PRECISION_FORMATS.get(len(label))
+    if fmt is None:
+        supported = ", ".join(sorted(_PRECISION_FORMATS.values(), key=len))
+        raise ValueError(
+            f"{text!r} is not a supported date label. Supported precisions: {supported}."
+        )
+    return fmt
+
+
+def pad_label(text: str, *, upper: bool) -> str:
+    """Extend a partial date label to full precision, at the start or the end of its period.
+
+    ``"2024-01"`` names a *period*, not an instant: as the lower bound of a range it
+    means that period's first second, as the upper bound its last. Padding with the
+    matching template makes an inclusive string comparison behave that way. The upper
+    template pads to day 31 whatever the month's real length — the result is only ever
+    compared against decoded labels, never parsed, and no real label sorts above it.
+
+    Args:
+        text: A whole or partial date label.
+        upper: ``True`` pads to the last instant of the period, ``False`` to the first.
+
+    Returns:
+        str: A fully-qualified ``YYYY-MM-DD HH:MM:SS`` label.
+
+    Examples:
+        - A month as a lower bound is its first second:
+            ```python
+            >>> from pyramids.netcdf._label_select import pad_label
+            >>> pad_label("2024-01", upper=False)
+            '2024-01-01 00:00:00'
+
+            ```
+        - The same month as an upper bound is its last:
+            ```python
+            >>> from pyramids.netcdf._label_select import pad_label
+            >>> pad_label("2024-01", upper=True)
+            '2024-01-31 23:59:59'
+
+            ```
+    """
+    label = normalise_label(text)
+    label_format(label)
+    template = _UPPER_TEMPLATE if upper else _LOWER_TEMPLATE
+    return label + template[len(label) :]
+
+
+def has_label(selector: Any) -> bool:
+    """Return whether ``selector`` selects by date label rather than by stored value.
+
+    Args:
+        selector: A ``sel`` selector — a scalar, a list, or a :class:`slice`.
+
+    Returns:
+        bool: ``True`` when the selector carries at least one string.
+
+    Examples:
+        - A date string selects by label:
+            ```python
+            >>> from pyramids.netcdf._label_select import has_label
+            >>> has_label("2024-01-01")
+            True
+
+            ```
+        - A slice of stored values does not:
+            ```python
+            >>> from pyramids.netcdf._label_select import has_label
+            >>> has_label(slice(500, 1000))
+            False
+
+            ```
+    """
+    if isinstance(selector, slice):
+        parts: tuple[Any, ...] = (selector.start, selector.stop)
+    elif isinstance(selector, list):
+        parts = tuple(selector)
+    else:
+        parts = (selector,)
+    return any(isinstance(part, str) for part in parts)
+
+
+def _label_slice_indices(
+    decode: Callable[[str], list[str]], selector: slice
+) -> list[int]:
+    """Indices whose decoded label falls inside an inclusive label slice.
+
+    Helper of :func:`label_indices`; bounds are padded to full precision so a partial
+    one covers its whole period, and swapped when the axis runs newest-first.
+    """
+    labels = decode(FULL_FORMAT)
+    start = None if selector.start is None else normalise_label(selector.start)
+    stop = None if selector.stop is None else normalise_label(selector.stop)
+    # Order the bounds *before* padding: which end a partial label extends to depends on
+    # whether it is the low or the high bound, not on which slot it was written in. An
+    # open bound falls back to the axis extreme rather than to its first/last value, so
+    # the slice stays direction-agnostic on an axis written newest-first.
+    if start is not None and stop is not None and start > stop:
+        start, stop = stop, start
+    low = min(labels) if start is None else pad_label(start, upper=False)
+    high = max(labels) if stop is None else pad_label(stop, upper=True)
+    return [i for i, label in enumerate(labels) if low <= label <= high]
+
+
+def label_indices(decode: Callable[[str], list[str]], selector: Any) -> list[int]:
+    """Resolve a date-label selector against a CF time axis.
+
+    Each label is matched at its own precision: the axis is decoded with the format
+    :func:`label_format` returns for that label, so ``"2024-01-01"`` matches every step
+    of that day while ``"2024-01-01 06:00:00"`` matches one. A list unions its labels;
+    a :class:`slice` compares fully-qualified labels with inclusive, period-aware bounds.
+
+    Args:
+        decode: Callable turning a strftime format into the axis' decoded labels, one
+            per coordinate value (``nc._decode_time_labels`` bound to the dimension).
+        selector: A label, a list of labels, or a :class:`slice` of labels.
+
+    Returns:
+        list[int]: Ascending indices of the matching coordinates; empty when none match.
+
+    Raises:
+        ValueError: A label is not one of the supported precisions.
+
+    Examples:
+        - A date-only label matches every step inside that day:
+            ```python
+            >>> from datetime import datetime, timedelta
+            >>> from pyramids.netcdf._label_select import label_indices
+            >>> steps = [
+            ...     datetime(2024, 1, 1) + timedelta(hours=h) for h in (0, 6, 12, 18)
+            ... ]
+            >>> def decode(fmt):
+            ...     return [step.strftime(fmt) for step in steps]
+            >>> label_indices(decode, "2024-01-01")
+            [0, 1, 2, 3]
+
+            ```
+        - A fully-qualified label matches exactly one:
+            ```python
+            >>> label_indices(decode, "2024-01-01 12:00:00")
+            [2]
+
+            ```
+        - A slice takes an inclusive range:
+            ```python
+            >>> label_indices(decode, slice("2024-01-01 06:00", "2024-01-01 12:00"))
+            [1, 2]
+
+            ```
+    """
+    if isinstance(selector, slice):
+        indices = _label_slice_indices(decode, selector)
+    else:
+        wanted = selector if isinstance(selector, list) else [selector]
+        found: set[int] = set()
+        for label in wanted:
+            normalised = normalise_label(label)
+            decoded = decode(label_format(normalised))
+            found.update(i for i, value in enumerate(decoded) if value == normalised)
+        indices = sorted(found)
+    return indices
+
+
+def _is_number(value: Any) -> bool:
+    """Return whether ``value`` is a real number — ``bool`` excluded. Helper of ``nearest_indices``.
+
+    Tests against :class:`numbers.Real` rather than ``(int, float)`` so a numpy scalar
+    off a coordinate array counts: ``np.int64`` is registered as ``Integral`` but is not
+    an ``int`` subclass.
+    """
+    return isinstance(value, numbers.Real) and not isinstance(value, bool)
+
+
+def nearest_indices(coords: list, selector: Any) -> list[int]:
+    """Snap a numeric selector to the closest coordinate(s) on an axis.
+
+    Args:
+        coords: The axis' stored coordinate values.
+        selector: A number, or a list of numbers (each snapped independently).
+
+    Returns:
+        list[int]: Ascending indices of the snapped coordinates — one per requested
+            value, deduplicated when two requests snap to the same coordinate.
+
+    Raises:
+        ValueError: The selector is a :class:`slice` (a range has no nearest value), or
+            either the selector or the axis is not numeric.
+
+    Examples:
+        - A value between two levels snaps to the closer one:
+            ```python
+            >>> from pyramids.netcdf._label_select import nearest_indices
+            >>> nearest_indices([1000.0, 925.0, 850.0, 700.0], 900.0)
+            [1]
+
+            ```
+        - Each value in a list snaps independently:
+            ```python
+            >>> nearest_indices([1000.0, 925.0, 850.0, 700.0], [990.0, 710.0])
+            [0, 3]
+
+            ```
+    """
+    if isinstance(selector, slice):
+        raise ValueError(
+            "method='nearest' does not accept a slice selector — a range has no nearest "
+            "value. Drop `method` to take the range, or pass a value or a list of values."
+        )
+    wanted = selector if isinstance(selector, list) else [selector]
+    if not all(_is_number(value) for value in wanted):
+        raise ValueError(
+            f"method='nearest' needs numeric selector values, got {selector!r}."
+        )
+    if not all(_is_number(value) for value in coords):
+        raise ValueError(
+            f"method='nearest' needs a numeric coordinate axis, got {coords!r}."
+        )
+    found: set[int] = set()
+    for value in wanted:
+        distances = [abs(coord - value) for coord in coords]
+        found.add(distances.index(min(distances)))
+    return sorted(found)

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import math
 import numbers
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -30,6 +31,13 @@ FULL_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 _LOWER_TEMPLATE = "0001-01-01 00:00:00"
 _UPPER_TEMPLATE = "9999-12-31 23:59:59"
+
+# A label is recognised by its *shape*, not merely its length: "control" is seven
+# characters like "2024-01" but is an ensemble member's name, not a date, and belongs on
+# the stored-value path.
+_LABEL_PATTERN = re.compile(
+    r"\d{4}(?:-\d{2}(?:-\d{2}(?:[ ]\d{2}(?::\d{2}(?::\d{2})?)?)?)?)?\Z"
+)
 
 _PRECISION_FORMATS = {
     4: "%Y",
@@ -118,7 +126,7 @@ def label_format(text: str) -> str:
         pad_label: extends a partial label to the edge of the period it names.
     """
     label = normalise_label(text)
-    fmt = _PRECISION_FORMATS.get(len(label))
+    fmt = _PRECISION_FORMATS.get(len(label)) if _LABEL_PATTERN.match(label) else None
     if fmt is None:
         supported = ", ".join(sorted(_PRECISION_FORMATS.values(), key=len))
         raise ValueError(
@@ -258,6 +266,95 @@ def non_label_parts(selector: Any) -> list[Any]:
     else:
         parts = (selector,)
     return [part for part in parts if not isinstance(part, str)]
+
+
+def first_label(selector: Any) -> str | None:
+    """The first string in a selector, or ``None`` when it carries none.
+
+    Args:
+        selector: A ``sel`` selector — a scalar, a list, or a :class:`slice`.
+
+    Returns:
+        str or None: The first string part, in the order the selector writes them.
+
+    Examples:
+        - A list answers with its first label:
+            ```python
+            >>> from pyramids.netcdf._label_select import first_label
+            >>> first_label(["2024-01-02", "2024-01-03"])
+            '2024-01-02'
+
+            ```
+        - A purely numeric selector has none:
+            ```python
+            >>> from pyramids.netcdf._label_select import first_label
+            >>> first_label(slice(500, 1000)) is None
+            True
+
+            ```
+    """
+    if isinstance(selector, slice):
+        parts: tuple[Any, ...] = (selector.start, selector.stop)
+    elif isinstance(selector, list):
+        parts = tuple(selector)
+    else:
+        parts = (selector,)
+    return next((part for part in parts if isinstance(part, str)), None)
+
+
+def probe_format(selector: Any) -> str | None:
+    """The precision an axis must decode at to answer this label selector.
+
+    Lets a caller test "does this axis decode at all" with the *same* format the match
+    will use, so a memoised decoder answers both from one pass over the axis instead of
+    decoding the whole coordinate variable again.
+
+    Args:
+        selector: A label selector — a label, a list of them, or a :class:`slice`.
+
+    Returns:
+        str or None: :data:`FULL_FORMAT` for a slice, whose bounds are compared at full
+            precision; the format of the selector's first label otherwise; and ``None``
+            when the selector carries no string, or its string is not a date-label shape
+            at all (``"control"``, ``"850"``) — such a selector is a stored value, not a
+            label, and belongs on the exact-match path.
+
+    Examples:
+        - A date-only label only needs the axis decoded to dates:
+            ```python
+            >>> from pyramids.netcdf._label_select import probe_format
+            >>> probe_format("2024-01-01")
+            '%Y-%m-%d'
+
+            ```
+        - A slice compares fully-qualified labels:
+            ```python
+            >>> from pyramids.netcdf._label_select import probe_format
+            >>> probe_format(slice("2024-01", "2024-03"))
+            '%Y-%m-%d %H:%M:%S'
+
+            ```
+        - A string that is not a date label at all is not a label selection:
+            ```python
+            >>> from pyramids.netcdf._label_select import probe_format
+            >>> probe_format("control") is None
+            True
+
+            ```
+    """
+    label = first_label(selector)
+    if isinstance(selector, slice) and label is not None:
+        fmt: str | None = FULL_FORMAT
+    elif label is None:
+        fmt = None
+    else:
+        normalised = normalise_label(label)
+        fmt = (
+            _PRECISION_FORMATS.get(len(normalised))
+            if _LABEL_PATTERN.match(normalised)
+            else None
+        )
+    return fmt
 
 
 def _label_slice_indices(

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -209,6 +209,56 @@ def has_label(selector: Any) -> bool:
     return any(isinstance(part, str) for part in parts)
 
 
+def non_label_parts(selector: Any) -> list[Any]:
+    """Parts of a label selector that are not labels — empty when it is purely labels.
+
+    :func:`has_label` is true when *any* part of a selector is a string, but the label
+    path assumes *every* part is. This names the parts that would break it, so the caller
+    can refuse a half-converted selector such as ``slice("2024-01-01", 12)`` with a
+    message instead of an ``AttributeError`` from inside the matcher. An open slice bound
+    (``None``) is not a stray part — it means "the end of the axis".
+
+    Args:
+        selector: A ``sel`` selector — a scalar, a list, or a :class:`slice`.
+
+    Returns:
+        list: The non-string parts, in the order they appear; empty when every part is a
+            label (or an open slice bound).
+
+    Examples:
+        - A selector that is entirely labels has no stray parts:
+            ```python
+            >>> from pyramids.netcdf._label_select import non_label_parts
+            >>> non_label_parts(["2024-01-01", "2024-01-02"])
+            []
+
+            ```
+        - A half-converted range names the part that does not belong:
+            ```python
+            >>> from pyramids.netcdf._label_select import non_label_parts
+            >>> non_label_parts(slice("2024-01-01", 12))
+            [12]
+
+            ```
+        - An open bound is not a stray part:
+            ```python
+            >>> from pyramids.netcdf._label_select import non_label_parts
+            >>> non_label_parts(slice("2024-01-01", None))
+            []
+
+            ```
+    """
+    if isinstance(selector, slice):
+        parts: tuple[Any, ...] = tuple(
+            part for part in (selector.start, selector.stop) if part is not None
+        )
+    elif isinstance(selector, list):
+        parts = tuple(selector)
+    else:
+        parts = (selector,)
+    return [part for part in parts if not isinstance(part, str)]
+
+
 def _label_slice_indices(
     decode: Callable[[str], list[str]], selector: slice
 ) -> list[int]:

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -16,6 +16,13 @@ Two concerns live here:
 * **Nearest-value selection.** ``method="nearest"`` snaps a numeric selector to the
   closest coordinate on the axis, which is how a caller asks for "the level nearest
   100 m" without knowing the axis values up front.
+
+Ranges are compared as text, which is exact while ``%Y`` renders a zero-padded
+four-digit year — true for every calendar cftime decodes in the CE range, and the reason
+:data:`_UPPER_TEMPLATE` can stop at 9999. A palaeo or idealised axis outside that range
+would not sort correctly, and is not supported. The *labels* themselves are whatever the
+dimension's CF ``calendar`` produces, so a ``360_day`` axis with a real ``2024-02-30``
+sorts and pads like any other — nothing here assumes a Gregorian month length.
 """
 
 from __future__ import annotations

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -61,6 +61,13 @@ def _has_label_shape(label: str) -> bool:
     directly: every supported precision is a prefix of ``YYYY-MM-DD HH:MM:SS``, cut at
     one of the boundaries :data:`_PRECISION_FORMATS` names. The length gate is what keeps
     a bare ``"850"`` from reading as a three-digit year.
+
+    Args:
+        label: An already-normalised candidate label.
+
+    Returns:
+        bool: ``True`` when every position holds the digit or separator the template
+            requires, and the length is one of the supported precisions.
     """
     template = _LABEL_SHAPE[: len(label)]
     return len(label) in _PRECISION_FORMATS and all(

--- a/src/pyramids/netcdf/_label_select.py
+++ b/src/pyramids/netcdf/_label_select.py
@@ -103,6 +103,18 @@ def label_format(text: str) -> str:
             '%Y'
 
             ```
+        - A label between two precisions is rejected, listing the ones that work:
+            ```python
+            >>> from pyramids.netcdf._label_select import label_format
+            >>> label_format("2024-01-01 06:0")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: '2024-01-01 06:0' is not a supported date label. Supported...
+
+            ```
+
+    See Also:
+        pad_label: extends a partial label to the edge of the period it names.
     """
     label = normalise_label(text)
     fmt = _PRECISION_FORMATS.get(len(label))
@@ -176,6 +188,17 @@ def has_label(selector: Any) -> bool:
             False
 
             ```
+        - One label anywhere in a list is enough to make it a label selection:
+            ```python
+            >>> from pyramids.netcdf._label_select import has_label
+            >>> has_label(["2024-01-01", "2024-01-02"])
+            True
+
+            ```
+
+    See Also:
+        label_indices: resolves the selectors this predicate accepts.
+        nearest_indices: resolves the numeric selectors it rejects.
     """
     if isinstance(selector, slice):
         parts: tuple[Any, ...] = (selector.start, selector.stop)
@@ -302,10 +325,23 @@ def nearest_indices(coords: list, selector: Any) -> list[int]:
             ```
         - Each value in a list snaps independently:
             ```python
+            >>> from pyramids.netcdf._label_select import nearest_indices
             >>> nearest_indices([1000.0, 925.0, 850.0, 700.0], [990.0, 710.0])
             [0, 3]
 
             ```
+        - A range has no nearest value, so a slice is refused:
+            ```python
+            >>> from pyramids.netcdf._label_select import nearest_indices
+            >>> nearest_indices([1000.0, 925.0], slice(900, 1000))  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: method='nearest' does not accept a slice selector...
+
+            ```
+
+    See Also:
+        label_indices: the date-label counterpart, which this deliberately refuses.
     """
     if isinstance(selector, slice):
         raise ValueError(

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -942,7 +942,8 @@ class NetCDFPlot:
         `sel()`-pinned subset, so the chunks render path reads the unpinned variable and indexes
         this band rather than storage band 0. Reuses the exact band-index machinery `sel` uses
         (`_resolve_selector_indices` + `_map_dim_to_band_indices`) so the flat index matches the
-        eager selection's band order, `method=` and date labels included. Every band dim is pinned on this path (`run` asserts
+        eager selection's band order, `method=` and date labels included. Every band
+        dim is pinned on this path (`run` asserts
         `band_count == 1`), so the per-dim band sets intersect to a single band; returns `0` when no
         selector is active.
 

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -936,8 +936,8 @@ class NetCDFPlot:
         The lazy `read_array(chunks=)` re-reads the whole source variable and ignores the
         `sel()`-pinned subset, so the chunks render path reads the unpinned variable and indexes
         this band rather than storage band 0. Reuses the exact band-index machinery `sel` uses
-        (`_resolve_dim_indices` + `_map_dim_to_band_indices`) so the flat index matches the eager
-        selection's band order. Every band dim is pinned on this path (`run` asserts
+        (`_resolve_selector_indices` + `_map_dim_to_band_indices`) so the flat index matches the
+        eager selection's band order, `method=` and date labels included. Every band dim is pinned on this path (`run` asserts
         `band_count == 1`), so the per-dim band sets intersect to a single band; returns `0` when no
         selector is active.
 

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -19,6 +19,7 @@ import numpy as np
 from pyramids.dataset._plot_helpers import ModeSpec, RenderRequest
 from pyramids.dataset._plot_helpers import render_array as _render_array
 from pyramids.netcdf import _coord_match
+from pyramids.netcdf._label_select import has_label
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 
 if TYPE_CHECKING:
@@ -618,6 +619,25 @@ def _resolve_animate_labels(
     return labels
 
 
+def _dim_method(method: str | None, value: Any) -> str | None:
+    """The matching mode that applies to one resolved selector.
+
+    :class:`~pyramids.netcdf.plot_options.Selectors` carries a single ``method`` while
+    ``plot`` may pin several dimensions at once. ``"nearest"`` describes how to match a
+    *numeric* request; a date label already names a period, and ``sel`` rejects the
+    combination. Narrowing the flag per dimension is what lets one call pin a time label
+    exactly and snap a level — the natural way to use both features together.
+
+    Args:
+        method: The caller's ``Selectors.method`` — ``None`` or ``"nearest"``.
+        value: The resolved selector for one dimension.
+
+    Returns:
+        str or None: ``method`` for a numeric selector, ``None`` for a label one.
+    """
+    return None if has_label(value) else method
+
+
 class NetCDFPlot:
     """Owns the plotting pipeline for a :class:`~pyramids.netcdf.netcdf.NetCDF`.
 
@@ -741,7 +761,12 @@ class NetCDFPlot:
 
         pinned = nc
         for dim_name, value in resolved_sel.items():
-            pinned = pinned.sel(method=selectors.method, **{dim_name: value})
+            # `method` says how to match a *numeric* request. A date label already names a
+            # period, so snapping means nothing for it — applying the flag only where it
+            # applies lets one call pin a time label exactly and snap a level.
+            pinned = pinned.sel(
+                method=_dim_method(selectors.method, value), **{dim_name: value}
+            )
         if (
             not faceting_active
             and animate_dim is None
@@ -948,7 +973,7 @@ class NetCDFPlot:
                         f"No coordinate values available for dimension {dim_name!r}."
                     )
                 dim_indices, _ = _resolve_selector_indices(
-                    nc, dim_name, coords, value, method
+                    nc, dim_name, coords, value, _dim_method(method, value)
                 )
                 dim_axis = nc._band_dim_names.index(dim_name)
                 bands = set(_map_dim_to_band_indices(dim_axis, sizes, dim_indices))

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -741,7 +741,7 @@ class NetCDFPlot:
 
         pinned = nc
         for dim_name, value in resolved_sel.items():
-            pinned = pinned.sel(**{dim_name: value})
+            pinned = pinned.sel(method=selectors.method, **{dim_name: value})
         if (
             not faceting_active
             and animate_dim is None
@@ -798,7 +798,7 @@ class NetCDFPlot:
                 # resolved raster plane -- and index the flat band the selection pins to, instead of
                 # storage band 0 (which would silently draw the wrong slice; #728).
                 render_source = nc
-                render_band = self._flat_band_index(nc, resolved_sel)
+                render_band = self._flat_band_index(nc, resolved_sel, selectors.method)
             else:
                 self._maybe_log_lazy_hint(pinned)
                 render_source = pinned
@@ -903,7 +903,9 @@ class NetCDFPlot:
                 resolved[dim_name] = idx if dim_coords is None else dim_coords[idx]
         return resolved
 
-    def _flat_band_index(self, nc: NetCDF, resolved_sel: dict[str, Any]) -> int:
+    def _flat_band_index(
+        self, nc: NetCDF, resolved_sel: dict[str, Any], method: str | None = None
+    ) -> int:
         """Flat classic-band index the selection pins to, for the lazy (`chunks=`) render path.
 
         The lazy `read_array(chunks=)` re-reads the whole source variable and ignores the
@@ -917,6 +919,9 @@ class NetCDFPlot:
         Args:
             nc: The unpinned variable subset (carries the full band-dim metadata).
             resolved_sel: `{band_dim_name: label}` from `_resolve_selectors`.
+            method: Matching mode forwarded from `Selectors.method` — `None` (exact) or
+                `"nearest"`. Shared with the eager path so both resolve a selector the
+                same way. Defaults to None.
 
         Returns:
             int: The 0-based flat band index of the selected 2-D slice.
@@ -931,7 +936,7 @@ class NetCDFPlot:
             # cycle (selection imports NetCDFPlot from this module).
             from pyramids.netcdf.engines.selection import (
                 _map_dim_to_band_indices,
-                _resolve_dim_indices,
+                _resolve_selector_indices,
             )
 
             sizes = nc._band_dim_sizes
@@ -942,7 +947,9 @@ class NetCDFPlot:
                     raise ValueError(
                         f"No coordinate values available for dimension {dim_name!r}."
                     )
-                dim_indices = _resolve_dim_indices(coords, value)
+                dim_indices, _ = _resolve_selector_indices(
+                    nc, dim_name, coords, value, method
+                )
                 dim_axis = nc._band_dim_names.index(dim_name)
                 bands = set(_map_dim_to_band_indices(dim_axis, sizes, dim_indices))
                 candidate = bands if candidate is None else candidate & bands

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -19,7 +19,7 @@ import numpy as np
 from pyramids.dataset._plot_helpers import ModeSpec, RenderRequest
 from pyramids.dataset._plot_helpers import render_array as _render_array
 from pyramids.netcdf import _coord_match
-from pyramids.netcdf._label_select import has_label
+from pyramids.netcdf._label_select import probe_format
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 
 if TYPE_CHECKING:
@@ -628,14 +628,19 @@ def _dim_method(method: str | None, value: Any) -> str | None:
     combination. Narrowing the flag per dimension is what lets one call pin a time label
     exactly and snap a level — the natural way to use both features together.
 
+    The test is "is this a date label", not "is this a string": a non-label string such
+    as ``"850"`` is neither, and dropping ``method`` for it would swap ``sel``'s precise
+    "needs a numeric selector" complaint for a bare "no bands match" about the wrong
+    thing. Those keep the flag and reach that guard.
+
     Args:
         method: The caller's ``Selectors.method`` — ``None`` or ``"nearest"``.
         value: The resolved selector for one dimension.
 
     Returns:
-        str or None: ``method`` for a numeric selector, ``None`` for a label one.
+        str or None: ``None`` for a date-label selector, ``method`` for anything else.
     """
-    return None if has_label(value) else method
+    return None if probe_format(value) is not None else method
 
 
 class NetCDFPlot:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -845,6 +845,15 @@ class Selection(_Engine["NetCDF"]):
                 ```
 
         Notes:
+            A slice's `step` is ignored, on the label path as on the
+            stored-value one: `slice(a, b, 2)` selects the same bands
+            as `slice(a, b)`. Pass a list to pick specific values.
+
+            `method` is a keyword of this method, so a band dim
+            actually named `method` cannot be selected through it;
+            such a call reports "requires exactly one keyword
+            argument" because the selector was taken as the option.
+
             All six examples above are tagged `# doctest: +SKIP`
             because they need a real on-disk NetCDF fixture. The
             runnable equivalents live in:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1491,6 +1492,85 @@ def _undecodable_label_hint(
     return hint
 
 
+def _probe_label_format(
+    dim_name: str, selector: Any, decode: Callable[[str], list[str]]
+) -> str | None:
+    """The precision a label selector needs, after rejecting the ones that make no sense.
+
+    Helper of :func:`_resolve_selector_indices`, split out to keep the mode choice there
+    readable. Refuses a selector that mixes the two vocabularies, and -- on an axis that
+    *does* decode -- a string that is not a date-label shape, which is a malformed label
+    rather than a stored value.
+
+    Args:
+        dim_name: Name of the band dimension, for the error messages.
+        selector: The selector, already known to carry at least one string.
+        decode: The memoised axis decoder.
+
+    Returns:
+        str or None: The strftime format to match at, or ``None`` when the selector's
+            string is not date-shaped and the axis has no labels anyway.
+
+    Raises:
+        ValueError: The selector mixes labels with stored values, or names a date
+            precision that is not supported on an axis that decodes.
+    """
+    stray = non_label_parts(selector)
+    if stray:
+        raise ValueError(
+            f"{dim_name}={selector!r} mixes date labels with stored values "
+            f"({stray[0]!r}). Select by label or by stored value, not both."
+        )
+    probe = probe_format(selector)
+    if probe is None and decode(FULL_FORMAT):
+        # The axis decodes as time, so a string that is not a date-label shape is a
+        # malformed label, not a stored value -- `label_format` raises with the
+        # precisions that would have worked. On an axis that does *not* decode, the same
+        # string is simply a stored value (a string-valued coordinate variable, an
+        # ensemble member's name) and falls through to exact matching.
+        label_format(cast("str", first_label(selector)))
+    return probe
+
+
+def _nearest_or_raise(
+    dim_name: str, coords: list, selector: Any, probe: str | None, *, is_label: bool
+) -> list[int]:
+    """Snap a numeric selector, or explain why this one cannot be snapped.
+
+    Helper of :func:`_resolve_selector_indices`. The two refusals differ because the
+    advice does: a date label already names a period, while a non-date string has nothing
+    to measure at all.
+
+    Args:
+        dim_name: Name of the band dimension, for the error messages.
+        coords: That dimension's stored coordinate values.
+        selector: The selector handed to ``sel``.
+        probe: The label format resolved for the selector, or ``None``.
+        is_label: Whether the selector carries a string at all.
+
+    Returns:
+        list[int]: Indices of the snapped coordinates.
+
+    Raises:
+        ValueError: The selector is a date label, or is otherwise not a number.
+    """
+    if is_label and probe is not None:
+        raise ValueError(
+            f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is a "
+            "date label. Select a label exactly -- a partial label such as '2024-01' "
+            "already matches every step inside it."
+        )
+    if is_label:
+        # Not date-shaped, so the date-label advice would be nonsense: this is a string
+        # on an axis that has no labels at all (a pressure level written "850", an
+        # ensemble member's name).
+        raise ValueError(
+            f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is "
+            "not a number. Snapping compares distances, so it has nothing to measure."
+        )
+    return nearest_indices(coords, selector)
+
+
 def _resolve_selector_indices(
     nc: NetCDF,
     dim_name: str,
@@ -1504,10 +1584,10 @@ def _resolve_selector_indices(
     and the plot engine's ``_flat_band_index`` cannot drift apart:
 
     * ``method="nearest"`` snaps each numeric request to the closest coordinate.
-    * A selector carrying a string is a **date label**; the axis is decoded with the
-      dimension's CF ``units`` / ``calendar`` and matched as text. An axis that cannot be
-      decoded (no parseable ``units``) has no labels, so the stored-value path runs and
-      the caller reports "no bands match" against the raw values.
+    * A selector carrying a date-shaped string is a **label**; the axis is decoded with
+      the dimension's CF ``units`` / ``calendar`` and matched as text. An axis that cannot
+      be decoded has no labels, so the stored-value path runs and the caller reports "no
+      bands match" against the raw values.
     * Everything else matches the stored values exactly.
 
     Args:
@@ -1519,23 +1599,22 @@ def _resolve_selector_indices(
 
     Returns:
         tuple[list[int], list]: The matching indices along ``dim_name``, and the values
-            they were matched against — the decoded labels on a label selection, the
-            stored coordinates otherwise — so the caller's error message quotes the
+            they were matched against -- the decoded labels on a label selection, the
+            stored coordinates otherwise -- so the caller's error message quotes the
             vocabulary the caller actually used.
 
     Raises:
-        ValueError: ``"nearest"`` was asked of a date label, a slice, or a non-numeric
-            axis.
+        ValueError: The selector mixes labels with stored values, names an unsupported
+            date precision, or asks ``"nearest"`` of something that is not a number.
     """
-
     decoded: dict[str, list[str]] = {}
 
     def decode(fmt: str) -> list[str]:
         """Decode the axis at one precision, once; empty when it cannot be decoded at all.
 
         ``strict=False`` is the selection contract: a coordinate **value** the converter
-        chokes on — a ``_FillValue``, an infinity, an out-of-range offset, a string, or
-        anything cftime refuses on a non-standard calendar — means this axis has no
+        chokes on -- a ``_FillValue``, an infinity, an out-of-range offset, a string, or
+        anything cftime refuses on a non-standard calendar -- means this axis has no
         labels, not that the caller's ``sel`` should abort. The stored-value path can
         still answer it.
         """
@@ -1545,45 +1624,19 @@ def _resolve_selector_indices(
             )
         return decoded[fmt]
 
-    label_selection = has_label(selector)
-    if label_selection:
-        stray = non_label_parts(selector)
-        if stray:
-            raise ValueError(
-                f"{dim_name}={selector!r} mixes date labels with stored values "
-                f"({stray[0]!r}). Select by label or by stored value, not both."
-            )
     # Probe at the precision this selector needs rather than always at FULL_FORMAT: the
     # match then answers from the same memoised pass, so a decodable axis is decoded once
     # per distinct precision instead of up to four times over the whole coordinate
-    # variable — which on a 128k-step cloud axis is the difference between one cftime
+    # variable -- which on a 128k-step cloud axis is the difference between one cftime
     # pass per `sel` and four, one of them only ever used to build an error string.
-    probe = probe_format(selector) if label_selection else None
-    if label_selection and probe is None and decode(FULL_FORMAT):
-        # The axis decodes as time, so a string that is not a date-label shape is a
-        # malformed label, not a stored value — `label_format` raises with the precisions
-        # that would have worked. On an axis that does *not* decode, the same string is
-        # simply a stored value (a string-valued coordinate variable, an ensemble member
-        # name) and falls through to exact matching below.
-        label_format(cast("str", first_label(selector)))
-    decodable = probe is not None and bool(decode(probe))
+    is_label = has_label(selector)
+    probe = _probe_label_format(dim_name, selector, decode) if is_label else None
     if method == "nearest":
-        if label_selection and probe is not None:
-            raise ValueError(
-                f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is a "
-                "date label. Select a label exactly — a partial label such as '2024-01' "
-                "already matches every step inside it."
-            )
-        if label_selection:
-            # Not date-shaped, so the date-label advice would be nonsense: this is a
-            # string on an axis that has no labels at all (a pressure level written
-            # "850", an ensemble member's name).
-            raise ValueError(
-                f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is "
-                "not a number. Snapping compares distances, so it has nothing to measure."
-            )
-        indices, available = nearest_indices(coords, selector), coords
-    elif decodable:
+        indices = _nearest_or_raise(
+            dim_name, coords, selector, probe, is_label=is_label
+        )
+        available = coords
+    elif probe is not None and decode(probe):
         indices = label_indices(decode, selector)
         # Only a failed match needs the vocabulary spelled out, and only then is the
         # full-precision decode worth paying for.
@@ -1592,7 +1645,7 @@ def _resolve_selector_indices(
         try:
             indices = _resolve_dim_indices(coords, selector)
         except TypeError:
-            # A stored-value comparison the types cannot answer — a string-bounded slice
+            # A stored-value comparison the types cannot answer -- a string-bounded slice
             # against a numeric axis, which is what a label slice degrades to when the
             # axis has no labels. A scalar or a list simply never equals any coordinate
             # and reports "no bands match"; a slice used to raise `TypeError` instead,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -37,6 +37,12 @@ from pyramids.dataset.engines.spatial import (
     _stitch_lon_halves,
 )
 from pyramids.feature import FeatureCollection
+from pyramids.netcdf._label_select import (
+    FULL_FORMAT,
+    has_label,
+    label_indices,
+    nearest_indices,
+)
 from pyramids.netcdf._mdim import open_mdarray, scalar_no_data
 from pyramids.netcdf._plot import NetCDFPlot
 from pyramids.netcdf.array_options import GeoReference
@@ -684,7 +690,7 @@ class Selection(_Engine["NetCDF"]):
         result._curvilinear_coords = (lon_win, lat_win)
         return result
 
-    def sel(self, **kwargs: Any) -> NetCDF:
+    def sel(self, *, method: str | None = None, **kwargs: Any) -> NetCDF:
         """Select a subset of bands by coordinate values along a band dim.
 
         Extracts bands whose coordinate values match the given criteria.
@@ -711,6 +717,16 @@ class Selection(_Engine["NetCDF"]):
         `band_indices == dim_indices`.
 
         Args:
+            method: How a selector is matched against the axis.
+                `None` (the default) matches exactly; `"nearest"`
+                snaps each requested value to the closest coordinate,
+                so a caller can ask for "the level nearest 100 m"
+                without knowing the axis values. `"nearest"` needs a
+                numeric selector — it rejects a `slice` (a range has
+                no nearest value) and a date label (select a label
+                exactly; a partial one already names a period). The
+                coordinate it chose is on the result, readable with
+                `get_dimension_values(dim)`.
             **kwargs: Exactly one keyword argument. The key must name a
                 tracked band dim (one of `self._band_dim_names`); the
                 value is one of:
@@ -723,6 +739,17 @@ class Selection(_Engine["NetCDF"]):
                   direction-agnostic — works on both ascending and
                   descending coord axes (e.g. `latitude` stored
                   north-to-south).
+                - A date label, a list of them, or a slice of them, on
+                  a CF time axis: `"2024-01-01"`. The axis is stored as
+                  raw offsets (`[0.0, 6.0, 12.0, 18.0]`), so a label is
+                  matched by decoding the axis with the dimension's
+                  `units` / `calendar` at the label's own precision —
+                  meaning a partial label matches every step inside the
+                  period it names (`"2024-01"` takes the whole month,
+                  `"2024-01-01 06:00:00"` takes one step). This is the
+                  form `get_time_variable` hands back. An axis whose
+                  `units` cannot be parsed has no labels to match, and a
+                  label selector on it finds nothing.
 
         Returns:
             NetCDF: A new variable subset with only the selected bands
@@ -734,11 +761,13 @@ class Selection(_Engine["NetCDF"]):
                 in the map.
 
         Raises:
-            ValueError: If exactly one kwarg isn't passed, the variable
-                has no tracked band dims, the named dim isn't one of
+            ValueError: If exactly one kwarg isn't passed, `method` is
+                neither `None` nor `"nearest"`, the variable has no
+                tracked band dims, the named dim isn't one of
                 `_band_dim_names`, the dim has no coord values
-                (`_band_dim_values_map[dim] is None`), or no bands match
-                the selector.
+                (`_band_dim_values_map[dim] is None`), `"nearest"` is
+                asked of a slice / a date label / a non-numeric axis,
+                or no bands match the selector.
 
         Examples:
             - Pin a pressure level on a 4-D file:
@@ -775,6 +804,23 @@ class Selection(_Engine["NetCDF"]):
                 [1000.0, 850.0, 500.0]
 
                 ```
+            - Snap to the nearest level, then read back which one was
+              chosen:
+                ```python
+                >>> sub = var.sel(pressure_level=900, method="nearest")  # doctest: +SKIP
+                >>> sub.get_dimension_values("pressure_level")  # doctest: +SKIP
+                array([850.])
+
+                ```
+            - Select a time step by its date label — the form
+              `get_time_variable()` returns — rather than by the raw
+              CF offset:
+                ```python
+                >>> sub = var.sel(time="2024-01-01 12:00:00")  # doctest: +SKIP
+                >>> sub._band_dim_values_map["time"]  # doctest: +SKIP
+                [12.0]
+
+                ```
 
         Notes:
             All four examples above are tagged `# doctest: +SKIP`
@@ -798,6 +844,10 @@ class Selection(_Engine["NetCDF"]):
         nc = self._ds
         if len(kwargs) != 1:
             raise ValueError("sel() requires exactly one keyword argument.")
+        if method not in (None, "nearest"):
+            raise ValueError(
+                f"sel() method must be None (exact) or 'nearest', got {method!r}."
+            )
 
         dim_name, selector = next(iter(kwargs.items()))
 
@@ -818,10 +868,12 @@ class Selection(_Engine["NetCDF"]):
                 f"No coordinate values available for dimension {dim_name!r}."
             )
 
-        dim_indices = _resolve_dim_indices(coords, selector)
+        dim_indices, available = _resolve_selector_indices(
+            nc, dim_name, coords, selector, method
+        )
         if not dim_indices:
             raise ValueError(
-                f"No bands match {dim_name}={selector}. Available values: {coords}"
+                f"No bands match {dim_name}={selector}. Available values: {available}"
             )
 
         dim_axis = nc._band_dim_names.index(dim_name)
@@ -1363,6 +1415,63 @@ def _resolve_dim_indices(coords: list, selector: Any) -> list[int]:
         coord_set = set(selector)
         return [i for i, v in enumerate(coords) if v in coord_set]
     return [i for i, v in enumerate(coords) if v == selector]
+
+
+def _resolve_selector_indices(
+    nc: NetCDF,
+    dim_name: str,
+    coords: list,
+    selector: Any,
+    method: str | None = None,
+) -> tuple[list[int], list]:
+    """Resolve one ``sel`` selector to band-dim indices, and the values it matched against.
+
+    The single place the three matching modes are chosen between, so :meth:`Selection.sel`
+    and the plot engine's ``_flat_band_index`` cannot drift apart:
+
+    * ``method="nearest"`` snaps each numeric request to the closest coordinate.
+    * A selector carrying a string is a **date label**; the axis is decoded with the
+      dimension's CF ``units`` / ``calendar`` and matched as text. An axis that cannot be
+      decoded (no parseable ``units``) has no labels, so the stored-value path runs and
+      the caller reports "no bands match" against the raw values.
+    * Everything else matches the stored values exactly.
+
+    Args:
+        nc: The variable subset being selected (carries the CF dimension attributes).
+        dim_name: Name of the band dimension the selector applies to.
+        coords: That dimension's stored coordinate values.
+        selector: The value, list, or :class:`slice` handed to ``sel``.
+        method: ``None`` for exact matching, ``"nearest"`` to snap. Defaults to ``None``.
+
+    Returns:
+        tuple[list[int], list]: The matching indices along ``dim_name``, and the values
+            they were matched against — the decoded labels on a label selection, the
+            stored coordinates otherwise — so the caller's error message quotes the
+            vocabulary the caller actually used.
+
+    Raises:
+        ValueError: ``"nearest"`` was asked of a date label, a slice, or a non-numeric
+            axis.
+    """
+
+    def decode(fmt: str) -> list[str]:
+        """Decode the axis at one precision; empty when its CF units cannot be parsed."""
+        return nc._decode_time_labels(dim_name, coords, fmt) or []
+
+    labels = decode(FULL_FORMAT) if has_label(selector) else []
+    if method == "nearest":
+        if has_label(selector):
+            raise ValueError(
+                f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is a "
+                "date label. Select a label exactly — a partial label such as '2024-01' "
+                "already matches every step inside it."
+            )
+        indices, available = nearest_indices(coords, selector), coords
+    elif labels:
+        indices, available = label_indices(decode, selector), cast("list", labels)
+    else:
+        indices, available = _resolve_dim_indices(coords, selector), coords
+    return indices, available
 
 
 def _map_dim_to_band_indices(

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -42,6 +42,7 @@ from pyramids.netcdf._label_select import (
     has_label,
     label_indices,
     nearest_indices,
+    non_label_parts,
 )
 from pyramids.netcdf._mdim import open_mdarray, scalar_no_data
 from pyramids.netcdf._plot import NetCDFPlot
@@ -1491,9 +1492,17 @@ def _resolve_selector_indices(
             labels = []
         return labels
 
-    labels = decode(FULL_FORMAT) if has_label(selector) else []
+    label_selection = has_label(selector)
+    if label_selection:
+        stray = non_label_parts(selector)
+        if stray:
+            raise ValueError(
+                f"{dim_name}={selector!r} mixes date labels with stored values "
+                f"({stray[0]!r}). Select by label or by stored value, not both."
+            )
+    labels = decode(FULL_FORMAT) if label_selection else []
     if method == "nearest":
-        if has_label(selector):
+        if label_selection:
             raise ValueError(
                 f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is a "
                 "date label. Select a label exactly — a partial label such as '2024-01' "

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -747,8 +747,13 @@ class Selection(_Engine["NetCDF"]):
                   meaning a partial label matches every step inside the
                   period it names (`"2024-01"` takes the whole month,
                   `"2024-01-01 06:00:00"` takes one step). This is the
-                  form `get_time_variable` hands back. An axis whose
-                  `units` cannot be parsed has no labels to match, and a
+                  vocabulary `get_time_variable` hands back — note its
+                  **default** `time_format` is `"%Y-%m-%d"`, so feeding
+                  one of its labels back selects that whole day; ask for
+                  `get_time_variable(dim, "%Y-%m-%d %H:%M:%S")` to get
+                  the labels that pin a single step. An axis whose
+                  `units` cannot be parsed, or whose values the CF
+                  converter cannot decode, has no labels to match, and a
                   label selector on it finds nothing.
 
         Returns:
@@ -812,13 +817,25 @@ class Selection(_Engine["NetCDF"]):
                 array([850.])
 
                 ```
-            - Select a time step by its date label — the form
-              `get_time_variable()` returns — rather than by the raw
-              CF offset:
+            - Select a time step by its date label rather than by the
+              raw CF offset. A full-precision label pins one step:
                 ```python
                 >>> sub = var.sel(time="2024-01-01 12:00:00")  # doctest: +SKIP
                 >>> sub._band_dim_values_map["time"]  # doctest: +SKIP
                 [12.0]
+
+                ```
+            - A label from `get_time_variable()` at its default
+              `"%Y-%m-%d"` names a **day**, so it keeps every step in
+              that day — ask for the finer format to pin one:
+                ```python
+                >>> nc.get_time_variable("time")[1]  # doctest: +SKIP
+                '2024-01-01'
+                >>> var.sel(time="2024-01-01")._band_dim_values_map["time"]  # doctest: +SKIP
+                [0.0, 6.0, 12.0, 18.0]
+                >>> fine = nc.get_time_variable("time", "%Y-%m-%d %H:%M:%S")  # doctest: +SKIP
+                >>> var.sel(time=fine[1])._band_dim_values_map["time"]  # doctest: +SKIP
+                [6.0]
 
                 ```
 

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -852,14 +852,14 @@ class Selection(_Engine["NetCDF"]):
               (`TestSelNearest` / `TestSelByDateLabel` — snapping and
               date-label selection, including the vocabulary a failed
               match reports and the axis whose units do not parse).
-            - `tests/netcdf/test_sel.py::TestSelSingleValue` /
+            - `tests/netcdf/selection/test_sel.py::TestSelSingleValue` /
               `TestSelList` / `TestSelSlice` (3-D scenarios — single
               value, list selector, slice selector including the
               direction-agnostic path).
-            - `tests/netcdf/test_sel_4d.py::TestSelByPressureLevel` /
+            - `tests/netcdf/selection/test_sel_4d.py::TestSelByPressureLevel` /
               `TestSelByTime` / `TestSelChained` (4-D scenarios —
               pin secondary / primary dim, chained `sel().sel()`).
-            - `tests/netcdf/test_sel_4d.py::TestSelErrorMessages` (the
+            - `tests/netcdf/selection/test_sel_4d.py::TestSelErrorMessages` (the
               error contract).
 
         See Also:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -823,10 +823,14 @@ class Selection(_Engine["NetCDF"]):
                 ```
 
         Notes:
-            All four examples above are tagged `# doctest: +SKIP`
+            All six examples above are tagged `# doctest: +SKIP`
             because they need a real on-disk NetCDF fixture. The
             runnable equivalents live in:
 
+            - `tests/netcdf/selection/test_sel_nearest_and_labels.py`
+              (`TestSelNearest` / `TestSelByDateLabel` — snapping and
+              date-label selection, including the vocabulary a failed
+              match reports and the axis whose units do not parse).
             - `tests/netcdf/test_sel.py::TestSelSingleValue` /
               `TestSelList` / `TestSelSlice` (3-D scenarios — single
               value, list selector, slice selector including the

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -1508,18 +1508,16 @@ def _resolve_selector_indices(
     def decode(fmt: str) -> list[str]:
         """Decode the axis at one precision, once; empty when it cannot be decoded at all.
 
-        ``_decode_time_labels`` guards only the *units* parse — a coordinate **value**
-        the converter chokes on still propagates, which is the right contract for a
-        display label but not for a selection. A ``_FillValue`` / NaN in a time axis, or
-        a coordinate variable holding strings, would abort a ``sel`` the stored-value
-        path can still answer. Catching it here makes an undecodable axis simply an axis
-        with no labels.
+        ``strict=False`` is the selection contract: a coordinate **value** the converter
+        chokes on — a ``_FillValue``, an infinity, an out-of-range offset, a string, or
+        anything cftime refuses on a non-standard calendar — means this axis has no
+        labels, not that the caller's ``sel`` should abort. The stored-value path can
+        still answer it.
         """
         if fmt not in decoded:
-            try:
-                decoded[fmt] = nc._decode_time_labels(dim_name, coords, fmt) or []
-            except (TypeError, ValueError):
-                decoded[fmt] = []
+            decoded[fmt] = (
+                nc._decode_time_labels(dim_name, coords, fmt, strict=False) or []
+            )
         return decoded[fmt]
 
     label_selection = has_label(selector)
@@ -1566,7 +1564,17 @@ def _resolve_selector_indices(
         # full-precision decode worth paying for.
         available = cast("list", decode(FULL_FORMAT)) if not indices else coords
     else:
-        indices, available = _resolve_dim_indices(coords, selector), coords
+        try:
+            indices = _resolve_dim_indices(coords, selector)
+        except TypeError:
+            # A stored-value comparison the types cannot answer — a string-bounded slice
+            # against a numeric axis, which is what a label slice degrades to when the
+            # axis has no labels. A scalar or a list simply never equals any coordinate
+            # and reports "no bands match"; a slice used to raise `TypeError` instead,
+            # outside the documented contract. Nothing matches, which is what the caller
+            # is then told.
+            indices = []
+        available = coords
     return indices, available
 
 

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -39,10 +39,13 @@ from pyramids.dataset.engines.spatial import (
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf._label_select import (
     FULL_FORMAT,
+    first_label,
     has_label,
+    label_format,
     label_indices,
     nearest_indices,
     non_label_parts,
+    probe_format,
 )
 from pyramids.netcdf._mdim import open_mdarray, scalar_no_data
 from pyramids.netcdf._plot import NetCDFPlot
@@ -1476,8 +1479,10 @@ def _resolve_selector_indices(
             axis.
     """
 
+    decoded: dict[str, list[str]] = {}
+
     def decode(fmt: str) -> list[str]:
-        """Decode the axis at one precision; empty when it cannot be decoded at all.
+        """Decode the axis at one precision, once; empty when it cannot be decoded at all.
 
         ``_decode_time_labels`` guards only the *units* parse — a coordinate **value**
         the converter chokes on still propagates, which is the right contract for a
@@ -1486,11 +1491,12 @@ def _resolve_selector_indices(
         path can still answer. Catching it here makes an undecodable axis simply an axis
         with no labels.
         """
-        try:
-            labels = nc._decode_time_labels(dim_name, coords, fmt) or []
-        except (TypeError, ValueError):
-            labels = []
-        return labels
+        if fmt not in decoded:
+            try:
+                decoded[fmt] = nc._decode_time_labels(dim_name, coords, fmt) or []
+            except (TypeError, ValueError):
+                decoded[fmt] = []
+        return decoded[fmt]
 
     label_selection = has_label(selector)
     if label_selection:
@@ -1500,7 +1506,20 @@ def _resolve_selector_indices(
                 f"{dim_name}={selector!r} mixes date labels with stored values "
                 f"({stray[0]!r}). Select by label or by stored value, not both."
             )
-    labels = decode(FULL_FORMAT) if label_selection else []
+    # Probe at the precision this selector needs rather than always at FULL_FORMAT: the
+    # match then answers from the same memoised pass, so a decodable axis is decoded once
+    # per distinct precision instead of up to four times over the whole coordinate
+    # variable — which on a 128k-step cloud axis is the difference between one cftime
+    # pass per `sel` and four, one of them only ever used to build an error string.
+    probe = probe_format(selector) if label_selection else None
+    if label_selection and probe is None and decode(FULL_FORMAT):
+        # The axis decodes as time, so a string that is not a date-label shape is a
+        # malformed label, not a stored value — `label_format` raises with the precisions
+        # that would have worked. On an axis that does *not* decode, the same string is
+        # simply a stored value (a string-valued coordinate variable, an ensemble member
+        # name) and falls through to exact matching below.
+        label_format(cast("str", first_label(selector)))
+    decodable = probe is not None and bool(decode(probe))
     if method == "nearest":
         if label_selection:
             raise ValueError(
@@ -1509,8 +1528,11 @@ def _resolve_selector_indices(
                 "already matches every step inside it."
             )
         indices, available = nearest_indices(coords, selector), coords
-    elif labels:
-        indices, available = label_indices(decode, selector), cast("list", labels)
+    elif decodable:
+        indices = label_indices(decode, selector)
+        # Only a failed match needs the vocabulary spelled out, and only then is the
+        # full-precision decode worth paying for.
+        available = cast("list", decode(FULL_FORMAT)) if not indices else coords
     else:
         indices, available = _resolve_dim_indices(coords, selector), coords
     return indices, available

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -898,7 +898,8 @@ class Selection(_Engine["NetCDF"]):
         )
         if not dim_indices:
             raise ValueError(
-                f"No bands match {dim_name}={selector}. Available values: {available}"
+                f"No bands match {dim_name}={selector}. "
+                f"Available values: {_summarise(available)}"
             )
 
         dim_axis = nc._band_dim_names.index(dim_name)
@@ -1442,6 +1443,29 @@ def _resolve_dim_indices(coords: list, selector: Any) -> list[int]:
     return [i for i, v in enumerate(coords) if v == selector]
 
 
+def _summarise(values: list, edge: int = 3) -> str:
+    """Render an axis' values for an error message, elided in the middle when long.
+
+    A typo'd selector is a routine mistake, and on a 128k-step time axis interpolating
+    every decoded label makes the exception string megabytes of timestamps. Show enough
+    of each end to recognise the vocabulary, and say how many there are.
+
+    Args:
+        values: The values the selector was matched against.
+        edge: How many to show at each end before eliding. Defaults to 3.
+
+    Returns:
+        str: The full list when it is short, else ``[first … last] (N values)``.
+    """
+    if len(values) <= edge * 2 + 1:
+        rendered = repr(values)
+    else:
+        head = ", ".join(repr(value) for value in values[:edge])
+        tail = ", ".join(repr(value) for value in values[-edge:])
+        rendered = f"[{head}, ..., {tail}] ({len(values)} values)"
+    return rendered
+
+
 def _resolve_selector_indices(
     nc: NetCDF,
     dim_name: str,
@@ -1521,11 +1545,19 @@ def _resolve_selector_indices(
         label_format(cast("str", first_label(selector)))
     decodable = probe is not None and bool(decode(probe))
     if method == "nearest":
-        if label_selection:
+        if label_selection and probe is not None:
             raise ValueError(
                 f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is a "
                 "date label. Select a label exactly — a partial label such as '2024-01' "
                 "already matches every step inside it."
+            )
+        if label_selection:
+            # Not date-shaped, so the date-label advice would be nonsense: this is a
+            # string on an axis that has no labels at all (a pressure level written
+            # "850", an ensemble member's name).
+            raise ValueError(
+                f"method='nearest' needs a numeric selector; {dim_name}={selector!r} is "
+                "not a number. Snapping compares distances, so it has nothing to measure."
             )
         indices, available = nearest_indices(coords, selector), coords
     elif decodable:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -1459,8 +1459,20 @@ def _resolve_selector_indices(
     """
 
     def decode(fmt: str) -> list[str]:
-        """Decode the axis at one precision; empty when its CF units cannot be parsed."""
-        return nc._decode_time_labels(dim_name, coords, fmt) or []
+        """Decode the axis at one precision; empty when it cannot be decoded at all.
+
+        ``_decode_time_labels`` guards only the *units* parse — a coordinate **value**
+        the converter chokes on still propagates, which is the right contract for a
+        display label but not for a selection. A ``_FillValue`` / NaN in a time axis, or
+        a coordinate variable holding strings, would abort a ``sel`` the stored-value
+        path can still answer. Catching it here makes an undecodable axis simply an axis
+        with no labels.
+        """
+        try:
+            labels = nc._decode_time_labels(dim_name, coords, fmt) or []
+        except (TypeError, ValueError):
+            labels = []
+        return labels
 
     labels = decode(FULL_FORMAT) if has_label(selector) else []
     if method == "nearest":

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -46,6 +46,7 @@ from pyramids.netcdf._label_select import (
     nearest_indices,
     non_label_parts,
     probe_format,
+    summarise_values,
 )
 from pyramids.netcdf._mdim import open_mdarray, scalar_no_data
 from pyramids.netcdf._plot import NetCDFPlot
@@ -897,9 +898,10 @@ class Selection(_Engine["NetCDF"]):
             nc, dim_name, coords, selector, method
         )
         if not dim_indices:
+            hint = _undecodable_label_hint(nc, dim_name, coords, selector)
             raise ValueError(
                 f"No bands match {dim_name}={selector}. "
-                f"Available values: {_summarise(available)}"
+                f"Available values: {summarise_values(available)}{hint}"
             )
 
         dim_axis = nc._band_dim_names.index(dim_name)
@@ -1443,27 +1445,41 @@ def _resolve_dim_indices(coords: list, selector: Any) -> list[int]:
     return [i for i, v in enumerate(coords) if v == selector]
 
 
-def _summarise(values: list, edge: int = 3) -> str:
-    """Render an axis' values for an error message, elided in the middle when long.
+def _undecodable_label_hint(
+    nc: NetCDF, dim_name: str, coords: list, selector: Any
+) -> str:
+    """Explain a failed label match on an axis whose CF values would not decode.
 
-    A typo'd selector is a routine mistake, and on a 128k-step time axis interpolating
-    every decoded label makes the exception string megabytes of timestamps. Show enough
-    of each end to recognise the vocabulary, and say how many there are.
+    Without this the caller sees the stored offsets and no reason why their label found
+    nothing — the axis *does* declare ``units``, so "it is not a time axis" would be the
+    wrong conclusion to draw. One coordinate is probed, not the whole axis, and only on
+    the failure path.
 
     Args:
-        values: The values the selector was matched against.
-        edge: How many to show at each end before eliding. Defaults to 3.
+        nc: The variable subset being selected.
+        dim_name: Name of the band dimension.
+        coords: That dimension's stored coordinate values.
+        selector: The selector that matched nothing.
 
     Returns:
-        str: The full list when it is short, else ``[first … last] (N values)``.
+        str: A trailing sentence for the error, or ``""`` when the axis simply has no
+            CF ``units`` (in which case the stored values are the whole story).
     """
-    if len(values) <= edge * 2 + 1:
-        rendered = repr(values)
-    else:
-        head = ", ".join(repr(value) for value in values[:edge])
-        tail = ", ".join(repr(value) for value in values[-edge:])
-        rendered = f"[{head}, ..., {tail}] ({len(values)} values)"
-    return rendered
+    hint = ""
+    if has_label(selector) and coords:
+        try:
+            decodes = (
+                nc._decode_time_labels(dim_name, coords[:1], FULL_FORMAT) is not None
+            )
+        except Exception:
+            decodes = True
+        if decodes:
+            hint = (
+                f" The {dim_name!r} axis declares CF units, but a coordinate value could"
+                " not be decoded, so it has no labels to match — these are its stored"
+                " values."
+            )
+    return hint
 
 
 def _resolve_selector_indices(

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6691,6 +6691,8 @@ class NetCDF(Dataset):
         var_name: str,
         raw_values: list[Any],
         time_format: str = "%Y-%m-%d",
+        *,
+        strict: bool = True,
     ) -> list[str] | None:
         """Decode already-read raw time values into formatted date strings.
 
@@ -6710,6 +6712,11 @@ class NetCDF(Dataset):
             raw_values: The raw coordinate values to decode (one per frame).
             time_format: strftime format for the output strings. Defaults to
                 ``"%Y-%m-%d"``.
+            strict: When ``True`` (the default) a coordinate value the converter
+                cannot handle propagates, so a malformed axis is not hidden behind
+                raw labels. When ``False`` it returns ``None`` instead, which is what
+                a selection needs: an axis that cannot be decoded simply has no labels
+                and the stored-value path still answers.
 
         Returns:
             list[str] or None: One formatted string per value, or ``None`` when no
@@ -6741,10 +6748,22 @@ class NetCDF(Dataset):
                 # None" contract and matching the pre-#1013 subset behaviour.
                 labels = None
                 continue
-            # The value conversion runs outside the guard, so a genuinely malformed
-            # coordinate value surfaces as an error rather than being hidden behind
-            # a silent raw-label fallback.
-            labels = [func(value) for value in raw_values]
+            # By default the value conversion runs outside the guard, so a genuinely
+            # malformed coordinate value surfaces as an error rather than being hidden
+            # behind a silent raw-label fallback. `strict=False` is for a *selection*,
+            # where a value the converter chokes on means "this axis has no labels" and
+            # the stored-value path can still answer — a `_FillValue`, an infinity or an
+            # out-of-range offset must not abort the caller's `sel`. The converters fail
+            # in several ways (`ValueError`, `OverflowError`, and `AttributeError` out of
+            # cftime), so the non-strict arm catches broadly; the metadata resolution
+            # above stays unguarded either way.
+            if strict:
+                labels = [func(value) for value in raw_values]
+            else:
+                try:
+                    labels = [func(value) for value in raw_values]
+                except Exception:
+                    labels = None
             break
         return labels
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6799,11 +6799,66 @@ class NetCDF(Dataset):
 
                 >>> nc.get_time_values("time")[:3]  # doctest: +SKIP
                 array([0, 3, 6])
+
+        See Also:
+            `get_dimension_values`: the same read for any dimension — this method is
+                the time-axis spelling of it.
         """
+        return self.get_dimension_values(var_name)
+
+    def get_dimension_values(self, name: str) -> np.typing.NDArray | None:
+        """Stored coordinate values of any dimension, or ``None`` if it has none.
+
+        The general form of :meth:`get_time_values` — the accessor for a *non-spatial,
+        non-time* axis (``level``, ``depth``, ``member``, …), whose values were
+        previously reachable only through the optional `to_xarray` bridge or by
+        provoking `sel`'s "Available values" error.
+
+        Answers from whichever source the receiver has:
+
+        * On a **variable subset** (what :meth:`get_variable` returns) a band dimension
+          is answered from the subset's own band-dim coordinates, so after a
+          :meth:`sel` the values reflect what that view actually holds — which is how a
+          `sel(..., method="nearest")` caller reads back the coordinate it snapped to.
+        * On a **root container** the coordinate variable is read from the store, for
+          any dimension it declares. A subset asked for a dimension it does not track —
+          its spatial axes — has no coordinate variable to read and answers ``None``;
+          those come from the geotransform (:meth:`get_x_lon_dimension_array`).
+
+        Values are the **stored** ones, matching what :meth:`sel` matches against. A CF
+        time axis is therefore raw offsets; :meth:`get_time_variable` decodes the same
+        axis to date strings.
+
+        Args:
+            name: Dimension name, as listed by :attr:`dimension_names` /
+                :attr:`dimension_sizes` (e.g. ``"level"``).
+
+        Returns:
+            numpy.ndarray or None: The coordinate values in storage order, or ``None``
+            when the dataset has no such dimension or it carries no coordinate variable.
+
+        Examples:
+            - Read the pressure levels of a 4-D cube, then the levels one `sel` kept::
+
+                >>> nc.get_dimension_values("level")  # doctest: +SKIP
+                array([1000.,  925.,  850.,  700.])
+                >>> nc.get_variable("rhum").sel(level=850).get_dimension_values("level")  # doctest: +SKIP
+                array([850.])
+
+        See Also:
+            `get_time_variable`: decodes a CF time axis to date strings.
+            `sel`: selects bands by these values.
+        """
+        tracked = self._band_dim_values_map.get(name)
         names = self.dimension_names
-        if names is None or var_name not in names:
-            return None
-        return self._read_variable(var_name)
+        values: np.typing.NDArray | None
+        if tracked is not None:
+            values = np.asarray(tracked)
+        elif names is not None and name in names:
+            values = self._read_variable(name)
+        else:
+            values = None
+        return values
 
     def _get_dimension_names(self) -> list[str] | None:
         """Return all dimension names, in storage order.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6791,7 +6791,9 @@ class NetCDF(Dataset):
 
         Returns:
             numpy.ndarray or None: The raw coordinate values, or ``None`` when
-            the store has no such dimension.
+            the store has no such dimension. On a variable subset the values are
+            that view's own — a time-subsetted cube reports the steps it kept, not
+            the source file's whole axis.
 
         Examples:
             - Raw 3-hourly offsets of the NWM retrospective cube (needs the

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6846,6 +6846,13 @@ class NetCDF(Dataset):
         Returns:
             numpy.ndarray or None: The coordinate values in storage order, or ``None``
             when the dataset has no such dimension or it carries no coordinate variable.
+            One caveat on a variable subset: a band dimension whose indexing variable
+            cannot be read — a string-typed one such as WRF's ``Times``, which the GDAL
+            SWIG bindings refuse — is tracked as the placeholder ``[0, 1, …, size - 1]``,
+            and comes back here as those integers rather than as ``None``. They are also
+            what :meth:`sel` matches against on such an axis, so the two agree; they are
+            just not the file's own labels. Read the container's dimension instead, or
+            the variable through :attr:`variables`, when you need the real values.
 
         Examples:
             - Read the pressure levels of a 4-D cube, then the levels one `sel` kept::
@@ -6865,9 +6872,35 @@ class NetCDF(Dataset):
         if tracked is not None:
             values = np.asarray(tracked)
         elif names is not None and name in names:
-            values = self._read_variable(name)
+            values = self._read_dimension_coordinates(name)
         else:
             values = None
+        return values
+
+    def _read_dimension_coordinates(self, name: str) -> np.typing.NDArray | None:
+        """Read one dimension's coordinate variable, string-typed axes included.
+
+        `_read_variable` goes through `ReadAsArray`, which the GDAL SWIG bindings refuse
+        for a character array — a WRF `Times` axis raised `RuntimeError: String buffer
+        data type not supported` straight out of the accessor. The list-based `Read()`
+        path handles those, and is the one `to_xarray` already uses for the same axes, so
+        falling back to it keeps the two reporting the same coordinates.
+
+        Args:
+            name: Dimension name, already known to be one this dataset declares.
+
+        Returns:
+            numpy.ndarray or None: The coordinate values, or `None` when the dimension
+            has no indexing variable to read.
+        """
+        try:
+            values = self._read_variable(name)
+        except RuntimeError:
+            dim = self._get_dimension(name)
+            indexing_var = None if dim is None else dim.GetIndexingVariable()
+            values = (
+                None if indexing_var is None else self._md_array_to_numpy(indexing_var)
+            )
         return values
 
     def _get_dimension_names(self) -> list[str] | None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3059,7 +3059,7 @@ class NetCDF(Dataset):
         The public surface is shaped around **variables** and **dimensions** — ``band``
         is not a NetCDF concept and has been removed from the signature. Variable
         selection is by name; the slice to render is pinned via a :class:`Selectors`
-        option bag (``time`` / ``level`` / ``member`` / ``sel`` / ``isel``); multi-panel
+        option bag (``time`` / ``level`` / ``member`` / ``sel`` / ``isel`` / ``method``); multi-panel
         layout is described by a :class:`FacetSpec` bag (``col`` / ``row`` / ``col_wrap``);
         and the spatial-axis interpretation by a :class:`CoordinateSpec` bag (``coords`` /
         ``x_dim`` / ``y_dim``). Each is a frozen dataclass — construct it inline at the call

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6866,12 +6866,10 @@ class NetCDF(Dataset):
             numpy.ndarray or None: The coordinate values in storage order, or ``None``
             when the dataset has no such dimension or it carries no coordinate variable.
             One caveat on a variable subset: a band dimension whose indexing variable
-            cannot be read — a string-typed one such as WRF's ``Times``, which the GDAL
-            SWIG bindings refuse — is tracked as the placeholder ``[0, 1, …, size - 1]``,
+            cannot be read at all is tracked as the placeholder ``[0, 1, …, size - 1]``
             and comes back here as those integers rather than as ``None``. They are also
             what :meth:`sel` matches against on such an axis, so the two agree; they are
-            just not the file's own labels. Read the container's dimension instead, or
-            the variable through :attr:`variables`, when you need the real values.
+            just not the file's own labels.
 
         Examples:
             - Read the pressure levels of a 4-D cube, then the levels one `sel` kept::
@@ -8683,15 +8681,21 @@ class NetCDF(Dataset):
         """Indexing-variable values for a band dimension, or integer indices when unreadable.
 
         String-typed indexing variables (e.g. WRF `Times`) cannot be read via `ReadAsArray` in the
-        GDAL SWIG bindings, so they fall back to `[0, 1, ..., size - 1]`.
+        GDAL SWIG bindings; the list-based `Read()` path handles those, and is the one the container
+        accessor and `to_xarray` use, so a subset reports the same coordinates as its container.
+        `[0, 1, ..., size - 1]` remains only when that read fails too.
         """
         indexing_var = dim.GetIndexingVariable()
         if indexing_var is None:
             return None
         try:
-            return indexing_var.ReadAsArray().tolist()
+            values = indexing_var.ReadAsArray().tolist()
         except RuntimeError:
-            return list(range(dim.GetSize()))
+            try:
+                values = NetCDF._md_array_to_numpy(indexing_var).tolist()
+            except Exception:
+                values = list(range(dim.GetSize()))
+        return values
 
     @staticmethod
     def _copy_variable_attrs(cube: NetCDF, md_arr) -> None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6827,9 +6827,17 @@ class NetCDF(Dataset):
           its spatial axes — has no coordinate variable to read and answers ``None``;
           those come from the geotransform (:meth:`get_x_lon_dimension_array`).
 
-        Values are the **stored** ones, matching what :meth:`sel` matches against. A CF
-        time axis is therefore raw offsets; :meth:`get_time_variable` decodes the same
-        axis to date strings.
+        Values are the **stored** ones, matching what :meth:`sel` matches against and what
+        ``to_xarray().coords`` reports for the same file. A CF time axis is therefore raw
+        offsets; :meth:`get_time_variable` decodes the same axis to date strings.
+
+        Storage order is also the *array* order, which for a **spatial** axis need not be
+        the raster's. Pyramids presents rasters north-up, but a south-to-north file stores
+        its latitudes ascending, so ``get_dimension_values("lat")`` comes back
+        ``[40, 41, …, 44]`` while :meth:`read_array`'s row 0 is the lat-44 row. Do not
+        index raster rows with this — :meth:`get_y_lat_dimension_array` builds the row
+        centres from the geotransform, in raster order. The values here answer "what does
+        this file store", which is the question :meth:`sel` and the CF metadata ask.
 
         Args:
             name: Dimension name, as listed by :attr:`dimension_names` /

--- a/src/pyramids/netcdf/plot_options.py
+++ b/src/pyramids/netcdf/plot_options.py
@@ -65,6 +65,12 @@ class Selectors:
             converted to the corresponding coord value via the
             variable's band-dim coord map; dims without coord values
             receive the int unchanged. Defaults to None.
+        method: How every label selector above is matched — ``None``
+            (the default) exactly, or ``"nearest"`` to snap each
+            numeric value to the closest coordinate on its axis.
+            Forwarded verbatim to :meth:`NetCDF.sel`, so the same
+            restrictions apply: ``"nearest"`` rejects a slice and a
+            date label. Defaults to None.
 
     Examples:
         - The default constructor produces an all-``None`` instance
@@ -92,6 +98,16 @@ class Selectors:
 
             ```
 
+        - Ask for the level nearest a target rather than an exact one:
+
+            ```python
+            >>> from pyramids.netcdf.plot_options import Selectors
+            >>> sel = Selectors(level=900, method="nearest")
+            >>> sel.method
+            'nearest'
+
+            ```
+
         - Frozen instances reject attribute assignment so the option
           bag stays stable after construction:
 
@@ -113,6 +129,7 @@ class Selectors:
     member: Any = None
     sel: dict[str, Any] | None = None
     isel: dict[str, int] | None = None
+    method: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pyramids/netcdf/plot_options.py
+++ b/src/pyramids/netcdf/plot_options.py
@@ -35,7 +35,7 @@ Examples:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(frozen=True)
@@ -110,6 +110,18 @@ class Selectors:
 
             ```
 
+        - An unknown matching mode is refused at construction, not
+          part-way through a render:
+
+            ```python
+            >>> from pyramids.netcdf.plot_options import Selectors
+            >>> Selectors(level=900, method="pad")
+            Traceback (most recent call last):
+                ...
+            ValueError: Selectors method must be None (exact) or 'nearest', got 'pad'.
+
+            ```
+
         - Frozen instances reject attribute assignment so the option
           bag stays stable after construction:
 
@@ -131,7 +143,20 @@ class Selectors:
     member: Any = None
     sel: dict[str, Any] | None = None
     isel: dict[str, int] | None = None
-    method: str | None = None
+    method: Literal["nearest"] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an unknown ``method`` where the caller typed it, not mid-render.
+
+        Raises:
+            ValueError: ``method`` is neither ``None`` nor ``"nearest"``. The wording
+                matches :meth:`NetCDF.sel`'s own guard, which would otherwise be the
+                first thing to complain — several frames into the plot.
+        """
+        if self.method not in (None, "nearest"):
+            raise ValueError(
+                f"Selectors method must be None (exact) or 'nearest', got {self.method!r}."
+            )
 
 
 @dataclass(frozen=True)

--- a/src/pyramids/netcdf/plot_options.py
+++ b/src/pyramids/netcdf/plot_options.py
@@ -65,12 +65,14 @@ class Selectors:
             converted to the corresponding coord value via the
             variable's band-dim coord map; dims without coord values
             receive the int unchanged. Defaults to None.
-        method: How every label selector above is matched — ``None``
-            (the default) exactly, or ``"nearest"`` to snap each
-            numeric value to the closest coordinate on its axis.
-            Forwarded verbatim to :meth:`NetCDF.sel`, so the same
-            restrictions apply: ``"nearest"`` rejects a slice and a
-            date label. Defaults to None.
+        method: How the selectors above are matched — ``None`` (the
+            default) exactly, or ``"nearest"`` to snap to the closest
+            coordinate on the axis. It applies only to the dims whose
+            selector is **numeric**: a date label already names a
+            period, so a dim pinned by label stays exact and the two
+            can be combined in one call (pin a time label, snap a
+            level). ``"nearest"`` still rejects a slice, which is a
+            range with no nearest value. Defaults to None.
 
     Examples:
         - The default constructor produces an all-``None`` instance

--- a/tests/netcdf/plot/_plot_helpers.py
+++ b/tests/netcdf/plot/_plot_helpers.py
@@ -1,4 +1,11 @@
-"""Shared in-memory NetCDF builders and render side-effects for the plot tests."""
+"""Shared in-memory NetCDF builders and render side-effects for the plot tests.
+
+Note on time coordinates: `NetCDF.from_array` writes no CF `units` on a dimension, so
+the cubes built here have no decodable time axis. A string time coordinate on one of
+them is matched as a **stored value**, by exact string comparison — not as a decoded CF
+date label. Tests that need the label path proper use an on-disk fixture whose `units`
+parse (e.g. `tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc`).
+"""
 
 from __future__ import annotations
 

--- a/tests/netcdf/plot/test_plot_lazy.py
+++ b/tests/netcdf/plot/test_plot_lazy.py
@@ -374,3 +374,38 @@ class TestNetCDFPlotLazySelectorMethod:
             exact,
             err_msg="method='nearest' should draw the slice of the snapped coordinate",
         )
+
+    @pytest.mark.lazy
+    def test_a_decoded_label_with_nearest_renders_the_same_lazily(self):
+        """A CF date label plus a snapped level draws the same plane on both paths.
+
+        Test scenario:
+            The in-memory helpers write no CF `units`, so their "labels" are stored
+            strings; this uses the on-disk fixture whose `hours since 2024-01-01`
+            decodes, which is the path the feature is about.
+        """
+        nc = NetCDF.read_file("tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc")
+        sel = Selectors(
+            sel={"time": "2024-01-01 06:00:00", "pressure_level": 900},
+            method="nearest",
+        )
+        eager = np.asarray(nc.plot(variable="temperature", selectors=sel).arr)
+        lazy = np.asarray(
+            nc.plot(
+                variable="temperature", selectors=sel, chunks={"rows": 2, "cols": 2}
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy,
+            eager,
+            err_msg="the chunked path drew a different slice for a decoded label",
+        )
+        exact = np.asarray(
+            nc.plot(
+                variable="temperature",
+                selectors=Selectors(sel={"time": 6.0, "pressure_level": 850.0}),
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy, exact, err_msg="label + nearest should equal the exact selection"
+        )

--- a/tests/netcdf/plot/test_plot_lazy.py
+++ b/tests/netcdf/plot/test_plot_lazy.py
@@ -331,3 +331,46 @@ class TestNetCDFPlotLazyEdges:
         assert not msgs, (
             f"Boundary at threshold (size == 100 MB) must not fire hint; got {msgs}"
         )
+
+
+class TestNetCDFPlotLazySelectorMethod:
+    """``Selectors.method`` reaches the lazy (`chunks=`) flat-band resolution too."""
+
+    @pytest.mark.lazy
+    def test_nearest_chunked_render_matches_the_eager_one(self, tmp_path):
+        """A snapped selector resolves to the same band on both render paths.
+
+        Test scenario:
+            The lazy path re-reads the whole variable and indexes the flat band
+            `_flat_band_index` resolves, so it has to apply `method=` exactly as the
+            eager `sel()` does. Asking for `pressure_level=520` with `method="nearest"`
+            on the `[1000, 500]` axis must draw the 500 hPa plane in both, and not the
+            (0, 0) corner band.
+        """
+        nc_mem = _make_4d_nc()
+        out = tmp_path / "cube4d_nearest.nc"
+        nc_mem.to_file(out)
+        nc = NetCDF.read_file(str(out))
+        sel = Selectors(time=6, sel={"pressure_level": 520}, method="nearest")
+        eager = np.asarray(nc.plot(variable="temperature", selectors=sel).arr)
+        lazy = np.asarray(
+            nc.plot(
+                variable="temperature", selectors=sel, chunks={"cols": 1, "rows": 1}
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy,
+            eager,
+            err_msg="chunked plot drew a different slice than eager under method='nearest'",
+        )
+        exact = np.asarray(
+            nc.plot(
+                variable="temperature",
+                selectors=Selectors(time=6, sel={"pressure_level": 500}),
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy,
+            exact,
+            err_msg="method='nearest' should draw the slice of the snapped coordinate",
+        )

--- a/tests/netcdf/plot/test_plot_options.py
+++ b/tests/netcdf/plot/test_plot_options.py
@@ -276,7 +276,7 @@ class TestSelectorsMethodValidation:
 
     def test_unknown_method_raises(self):
         """A typo'd mode fails where it was typed, not part-way through a render."""
-        with pytest.raises(ValueError, match="must be None \(exact\) or 'nearest'"):
+        with pytest.raises(ValueError, match=r"must be None \(exact\) or 'nearest'"):
             Selectors(level=900, method="pad")
 
     @pytest.mark.parametrize("method", [None, "nearest"])

--- a/tests/netcdf/plot/test_plot_options.py
+++ b/tests/netcdf/plot/test_plot_options.py
@@ -269,3 +269,17 @@ class TestPlotConsumesOptionDataclasses:
         assert captured["request"].mode.mode == "animate"
         assert captured["kw"]["data_style"].style == "topography"
         assert captured["kw"]["data_style"].hillshade is True
+
+
+class TestSelectorsMethodValidation:
+    """``Selectors`` refuses an unknown matching mode at construction."""
+
+    def test_unknown_method_raises(self):
+        """A typo'd mode fails where it was typed, not part-way through a render."""
+        with pytest.raises(ValueError, match="must be None \(exact\) or 'nearest'"):
+            Selectors(level=900, method="pad")
+
+    @pytest.mark.parametrize("method", [None, "nearest"])
+    def test_the_two_supported_modes_construct(self, method):
+        """Both accepted modes build cleanly."""
+        assert Selectors(level=900, method=method).method == method

--- a/tests/netcdf/plot/test_plot_selectors.py
+++ b/tests/netcdf/plot/test_plot_selectors.py
@@ -646,8 +646,9 @@ class TestNetCDFPlotSelectorMethod:
         """
         nc = _make_4d_nc()
         var = nc.get_variable("temperature")
+        selectors = Selectors(time=0, level=520)
         with pytest.raises(ValueError, match="No bands match"):
-            var.plot(selectors=Selectors(time=0, level=520))
+            var.plot(selectors=selectors)
 
 
 class TestNetCDFPlotSelectorMethodPerDim:
@@ -714,12 +715,11 @@ class TestNetCDFPlotSelectorMethodPerDim:
         """
         nc = _make_4d_nc()
         var = nc.get_variable("temperature")
+        selectors = Selectors(
+            sel={"time": 0, "pressure_level": "850"}, method="nearest"
+        )
         with pytest.raises(ValueError, match="is not a number"):
-            var.plot(
-                selectors=Selectors(
-                    sel={"time": 0, "pressure_level": "850"}, method="nearest"
-                )
-            )
+            var.plot(selectors=selectors)
 
 
 class TestNetCDFPlotSelectorMethodOnARealCFAxis:

--- a/tests/netcdf/plot/test_plot_selectors.py
+++ b/tests/netcdf/plot/test_plot_selectors.py
@@ -605,3 +605,44 @@ class TestNetCDFPlotIselNoCoordValues:
         sel = Selectors(isel={"time": 1})
         with pytest.raises(ValueError, match=r"No coordinate values"):
             var.plot(selectors=sel)
+
+
+class TestNetCDFPlotSelectorMethod:
+    """``Selectors.method`` reaches ``sel`` through the eager render path."""
+
+    def test_nearest_pins_the_snapped_slice(self):
+        """``method="nearest"`` renders the slice the snapped coordinate names.
+
+        Test scenario:
+            The 4-D fixture carries ``pressure_level=[1000, 500]``. Asking for 520 with
+            ``method="nearest"`` must render the same array as pinning 500 exactly.
+        """
+        nc = _make_4d_nc()
+        var = nc.get_variable("temperature")
+        expected = var.sel(time=0).sel(pressure_level=500).read_array()
+        captured: dict = {}
+
+        with patch.object(
+            type(var.analysis),
+            "plot",
+            autospec=True,
+            side_effect=_make_capture(captured),
+        ):
+            var.plot(selectors=Selectors(time=0, level=520, method="nearest"))
+        assert_array_equal(
+            captured["data"],
+            expected,
+            err_msg="method='nearest' should pin the slice of the snapped coordinate",
+        )
+
+    def test_default_method_still_requires_an_exact_value(self):
+        """Without ``method`` the same off-axis value is still rejected.
+
+        Test scenario:
+            ``Selectors(level=520)`` alone must raise, so snapping stays opt-in on the
+            plot path exactly as it is on ``sel``.
+        """
+        nc = _make_4d_nc()
+        var = nc.get_variable("temperature")
+        with pytest.raises(ValueError, match="No bands match"):
+            var.plot(selectors=Selectors(time=0, level=520))

--- a/tests/netcdf/plot/test_plot_selectors.py
+++ b/tests/netcdf/plot/test_plot_selectors.py
@@ -701,3 +701,20 @@ class TestNetCDFPlotSelectorMethodPerDim:
             expected,
             err_msg="a label selector must stay exact under method='nearest'",
         )
+
+    def test_a_non_label_string_still_reaches_sel_s_guard(self):
+        """A string that is neither numeric nor a date label keeps `method` and is told why.
+
+        Test scenario:
+            Narrowing on "is a string" dropped the flag for `"850"`, so the caller got
+            "No bands match pressure_level=850" — the wrong problem — instead of
+            `sel`'s "needs a numeric selector" explanation.
+        """
+        nc = _make_4d_nc()
+        var = nc.get_variable("temperature")
+        with pytest.raises(ValueError, match="is not a number"):
+            var.plot(
+                selectors=Selectors(
+                    sel={"time": 0, "pressure_level": "850"}, method="nearest"
+                )
+            )

--- a/tests/netcdf/plot/test_plot_selectors.py
+++ b/tests/netcdf/plot/test_plot_selectors.py
@@ -646,3 +646,58 @@ class TestNetCDFPlotSelectorMethod:
         var = nc.get_variable("temperature")
         with pytest.raises(ValueError, match="No bands match"):
             var.plot(selectors=Selectors(time=0, level=520))
+
+
+class TestNetCDFPlotSelectorMethodPerDim:
+    """``method`` applies per dim, so a label and a snapped value can be pinned together."""
+
+    def test_label_and_nearest_coexist(self):
+        """Pinning a time label exactly while snapping the level is a single call.
+
+        Test scenario:
+            ``method`` used to be handed to every dim, so a date label anywhere made the
+            whole call raise "needs a numeric selector". On a 4-D cube whose time axis
+            carries date strings, the label dim must stay exact while 520 snaps to the
+            500 hPa level.
+        """
+        nc = _make_4d_nc()
+        var = nc.get_variable("temperature")
+        stamps = ["2024-01-13", "2024-01-14", "2024-01-15"]
+        var._band_dim_values_map = dict(var._band_dim_values_map)
+        var._band_dim_values_map["time"] = list(stamps)
+        expected = var.sel(time="2024-01-14").sel(pressure_level=500).read_array()
+        captured: dict = {}
+
+        with patch.object(
+            type(var.analysis),
+            "plot",
+            autospec=True,
+            side_effect=_make_capture(captured),
+        ):
+            var.plot(
+                selectors=Selectors(time="2024-01-14", level=520, method="nearest")
+            )
+        assert_array_equal(
+            captured["data"],
+            expected,
+            err_msg="the label dim should stay exact while the numeric dim snaps",
+        )
+
+    def test_string_label_dim_is_not_snapped(self):
+        """A dim selected by label renders exactly even when ``method='nearest'`` is set."""
+        _nc, _times, var = _make_3d_nc_with_dates()
+        expected = var.sel(time="2024-01-15").read_array()
+        captured: dict = {}
+
+        with patch.object(
+            type(var.analysis),
+            "plot",
+            autospec=True,
+            side_effect=_make_capture(captured),
+        ):
+            var.plot(selectors=Selectors(time="2024-01-15", method="nearest"))
+        assert_array_equal(
+            captured["data"],
+            expected,
+            err_msg="a label selector must stay exact under method='nearest'",
+        )

--- a/tests/netcdf/plot/test_plot_selectors.py
+++ b/tests/netcdf/plot/test_plot_selectors.py
@@ -9,6 +9,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from pyramids.netcdf import Selectors
+from pyramids.netcdf._plot import NetCDFPlot
+from pyramids.netcdf.netcdf import NetCDF
 from tests.netcdf.conftest import make_plot_3d_nc
 from tests.netcdf.plot._plot_helpers import (
     _make_3d_nc_with_dates,
@@ -718,3 +720,62 @@ class TestNetCDFPlotSelectorMethodPerDim:
                     sel={"time": 0, "pressure_level": "850"}, method="nearest"
                 )
             )
+
+
+class TestNetCDFPlotSelectorMethodOnARealCFAxis:
+    """The label-plus-nearest combination on an axis whose CF units actually decode.
+
+    The in-memory helpers build their cubes with `from_array`, which writes no CF
+    `units`, so a string time coordinate there is matched by the plain string
+    exact-match fallback and the label decoder is never reached. This class uses the
+    on-disk fixture, where `hours since 2024-01-01` decodes, so the decoded-label path
+    is the one under test.
+    """
+
+    CF_PATH = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+
+    def test_a_decoded_label_and_a_snapped_level_pin_the_same_plane_as_exact_values(
+        self,
+    ):
+        """A CF date label and `method="nearest"` coexist and pin the expected slice.
+
+        Test scenario:
+            `time="2024-01-01 06:00:00"` decodes to offset 6 and stays exact, while 900
+            snaps to the 850 hPa level — the same plane as pinning 6.0 and 850 directly.
+        """
+        nc = NetCDF.read_file(self.CF_PATH)
+        var = nc.get_variable("temperature")
+        expected = var.sel(time=6.0).sel(pressure_level=850.0).read_array()
+        captured: dict = {}
+
+        with patch.object(
+            type(var.analysis),
+            "plot",
+            autospec=True,
+            side_effect=_make_capture(captured),
+        ):
+            var.plot(
+                selectors=Selectors(
+                    sel={"time": "2024-01-01 06:00:00", "pressure_level": 900},
+                    method="nearest",
+                )
+            )
+        assert_array_equal(
+            captured["data"],
+            expected,
+            err_msg="a decoded label should stay exact while the numeric dim snaps",
+        )
+
+    def test_the_flat_band_index_agrees(self):
+        """The lazy path resolves the same combination to the matching flat band.
+
+        Test scenario:
+            Time index 1 on a `(time=4, pressure_level=3)` cube starts at band 3; the
+            850 hPa level is level index 1, so the pinned band is 4.
+        """
+        nc = NetCDF.read_file(self.CF_PATH)
+        var = nc.get_variable("temperature")
+        index = NetCDFPlot(var)._flat_band_index(
+            var, {"time": "2024-01-01 06:00:00", "pressure_level": 900}, "nearest"
+        )
+        assert index == 4, f"got band {index}"

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -201,7 +201,7 @@ class TestSelByDateLabel:
 
     def test_unsupported_label_precision_is_rejected(self, cf_var):
         """A label at an unsupported precision raises rather than silently matching nothing."""
-        with pytest.raises(ValueError, match="Supported precisions"):
+        with pytest.raises(ValueError, match="Write one of"):
             cf_var.sel(time="2024-01-01 06:0")
 
 
@@ -362,7 +362,7 @@ class TestSelMixedVocabularySelectors:
 
     def test_a_non_date_string_on_a_time_axis_is_still_a_malformed_label(self, cf_var):
         """On an axis that does decode, a non-label string is a typo, and says so."""
-        with pytest.raises(ValueError, match="Supported precisions"):
+        with pytest.raises(ValueError, match="Write one of"):
             cf_var.sel(time="control")
 
 

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -235,3 +235,22 @@ class TestSelectorsMethodPlumbing:
             cf_var, {"time": "2024-01-01 06:00:00"}
         )
         assert index == len(LEVEL_VALUES), f"got band {index}"
+
+
+class TestSelSelectorVocabularyFallback:
+    """A string on an axis that is not a decodable CF time axis stays a stored value."""
+
+    def test_string_on_a_non_time_axis_matches_stored_values(self, cf_var):
+        """A string selector on a numeric non-time axis falls through to exact matching.
+
+        Test scenario:
+            ``pressure_level`` carries pressure units, not a CF time origin, so there
+            are no labels to decode against; the error quotes the stored values.
+        """
+        with pytest.raises(ValueError, match=r"Available values: \[1000.0"):
+            cf_var.sel(pressure_level="850")
+
+    def test_explicit_method_none_is_exact(self, cf_var):
+        """Passing ``method=None`` explicitly behaves exactly as omitting it."""
+        result = cf_var.sel(pressure_level=850, method=None)
+        assert result._band_dim_values_map["pressure_level"] == [850.0]

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -331,3 +331,31 @@ class TestGetTimeVariableRoundTrip:
             assert var.sel(time=label)._band_dim_values_map["time"] == [offset], (
                 f"{label!r} should select {offset}"
             )
+
+
+class TestSelMixedVocabularySelectors:
+    """A selector must be all labels or all stored values, and says so when it is not."""
+
+    @pytest.mark.parametrize(
+        "selector",
+        [
+            ["2024-01-01 06:00:00", 12],
+            slice("2024-01-01", 12),
+            slice(12, "2024-01-01"),
+        ],
+    )
+    def test_mixed_selector_raises_value_error(self, cf_var, selector):
+        """Mixing the two vocabularies raises the documented ``ValueError``.
+
+        Test scenario:
+            ``has_label`` is true when any part is a string while the matcher assumes
+            every part is, so these used to leak an ``AttributeError`` ('int' object has
+            no attribute 'strip') from inside a private helper.
+        """
+        with pytest.raises(ValueError, match="mixes date labels with stored values"):
+            cf_var.sel(time=selector)
+
+    def test_an_open_bound_is_not_a_mixed_selector(self, cf_var):
+        """A half-open label slice is still a pure label selection."""
+        result = cf_var.sel(time=slice("2024-01-01 12:00:00", None))
+        assert result._band_dim_values_map["time"] == [12.0, 18.0]

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -359,3 +359,45 @@ class TestSelMixedVocabularySelectors:
         """A half-open label slice is still a pure label selection."""
         result = cf_var.sel(time=slice("2024-01-01 12:00:00", None))
         assert result._band_dim_values_map["time"] == [12.0, 18.0]
+
+    def test_a_non_date_string_on_a_time_axis_is_still_a_malformed_label(self, cf_var):
+        """On an axis that does decode, a non-label string is a typo, and says so."""
+        with pytest.raises(ValueError, match="Supported precisions"):
+            cf_var.sel(time="control")
+
+
+class TestSelDecodesTheAxisOncePerPrecision:
+    """A label selection must not walk the whole coordinate axis more times than it needs."""
+
+    def _count_decodes(self, monkeypatch, var, selector):
+        """Run one `sel` and return how many times the axis was decoded."""
+        calls = {"n": 0}
+        original = NetCDF._decode_time_labels
+
+        def counted(self, *args, **kwargs):
+            calls["n"] += 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(NetCDF, "_decode_time_labels", counted)
+        var.sel(time=selector)
+        return calls["n"]
+
+    def test_a_list_of_labels_decodes_once(self, cf_var, monkeypatch):
+        """Three labels of one precision cost one pass, not one per label plus a probe.
+
+        Test scenario:
+            The resolver used to decode at full precision to test the axis, again per
+            label to match, and the first result was only ever used to build an error
+            message that a successful match never raises.
+        """
+        selector = [
+            "2024-01-01 00:00:00",
+            "2024-01-01 06:00:00",
+            "2024-01-01 12:00:00",
+        ]
+        assert self._count_decodes(monkeypatch, cf_var, selector) == 1
+
+    def test_a_label_slice_decodes_once(self, cf_var, monkeypatch):
+        """A slice compares full-precision labels, so one pass answers it."""
+        selector = slice("2024-01-01 00:00:00", "2024-01-01 12:00:00")
+        assert self._count_decodes(monkeypatch, cf_var, selector) == 1

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -1,0 +1,237 @@
+"""Tests for ``sel(method="nearest")`` and date-label selection (issue #1125).
+
+Two gaps this covers end to end on real fixtures:
+
+- ``sel`` matched a coordinate exactly, so asking for "the level nearest 100 m"
+  meant knowing the axis values up front.
+- A CF time axis is stored as raw offsets, so ``sel(time="2024-01-01")`` — the form
+  ``get_time_variable()`` hands back, and the form the plotting reference documents —
+  found nothing.
+
+Fixtures:
+- ``tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc`` — synthetic 4-D
+  ``(time=4, pressure_level=3, lat=5, lon=6)``, ``hours since 2024-01-01``, so the
+  time axis decodes and the level axis has gaps to snap into.
+- ``tests/data/netcdf/coards__5v__1d4-4d1__y-desc.nc`` — a COARDS cube whose
+  ``units`` do not parse, standing in for an axis with no labels at all.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports,
+descriptive assertion messages.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from pyramids.netcdf._plot import NetCDFPlot
+from pyramids.netcdf.netcdf import NetCDF
+from pyramids.netcdf.plot_options import Selectors
+
+pytestmark = pytest.mark.core
+
+CF_PATH = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+COARDS_PATH = "tests/data/netcdf/coards__5v__1d4-4d1__y-desc.nc"
+
+TIME_VALUES = [0.0, 6.0, 12.0, 18.0]
+LEVEL_VALUES = [1000.0, 850.0, 500.0]
+
+
+@pytest.fixture(scope="module")
+def cf_var() -> NetCDF:
+    """The ``temperature`` variable of the synthetic 4-D CF fixture."""
+    return NetCDF.read_file(CF_PATH).get_variable("temperature")
+
+
+@pytest.fixture(scope="module")
+def coards_var() -> NetCDF:
+    """The ``rhum`` variable of the COARDS fixture, whose time units do not parse."""
+    return NetCDF.read_file(COARDS_PATH).get_variable("rhum")
+
+
+class TestSelNearest:
+    """``method="nearest"`` snaps a value onto the axis instead of demanding an exact one."""
+
+    def test_value_between_levels_snaps_to_the_closer_one(self, cf_var):
+        """A level the cube does not carry snaps to its closest neighbour.
+
+        Test scenario:
+            ``sel(pressure_level=900, method="nearest")`` on ``[1000, 850, 500]`` →
+            the 850 hPa plane (|900-850| < |900-1000|).
+        """
+        result = cf_var.sel(pressure_level=900, method="nearest")
+        assert result._band_dim_values_map["pressure_level"] == [850.0], (
+            f"expected [850.0], got {result._band_dim_values_map['pressure_level']}"
+        )
+
+    def test_the_chosen_coordinate_is_readable_off_the_result(self, cf_var):
+        """The snapped coordinate is reported through the public accessor, not just internals.
+
+        Test scenario:
+            ``sel(..., method="nearest").get_dimension_values("pressure_level")`` → ``[850.]``.
+        """
+        result = cf_var.sel(pressure_level=900, method="nearest")
+        assert_array_equal(
+            result.get_dimension_values("pressure_level"),
+            np.array([850.0]),
+            err_msg="nearest should report which coordinate it chose",
+        )
+
+    def test_snapped_data_matches_the_exact_selection(self, cf_var):
+        """Snapping to a level reads the same data as selecting that level exactly."""
+        snapped = cf_var.sel(pressure_level=900, method="nearest").read_array()
+        exact = cf_var.sel(pressure_level=850).read_array()
+        assert_array_equal(snapped, exact, err_msg="nearest must not shift the data")
+
+    def test_exact_value_is_unchanged_by_nearest(self, cf_var):
+        """A value already on the axis snaps to itself, so ``method`` is a no-op there."""
+        result = cf_var.sel(pressure_level=500, method="nearest")
+        assert result._band_dim_values_map["pressure_level"] == [500.0]
+
+    def test_list_of_values_snaps_elementwise(self, cf_var):
+        """Every value in a list snaps independently and the result keeps axis order."""
+        result = cf_var.sel(pressure_level=[990, 520], method="nearest")
+        assert result._band_dim_values_map["pressure_level"] == [1000.0, 500.0], (
+            f"got {result._band_dim_values_map['pressure_level']}"
+        )
+
+    def test_nearest_works_on_the_time_axis_by_raw_offset(self, cf_var):
+        """Snapping applies to any numeric axis, the raw CF time offsets included."""
+        result = cf_var.sel(time=7, method="nearest")
+        assert result._band_dim_values_map["time"] == [6.0], (
+            f"got {result._band_dim_values_map['time']}"
+        )
+
+    def test_default_stays_exact(self, cf_var):
+        """Without ``method`` a missing value still raises — snapping is opt-in."""
+        with pytest.raises(ValueError, match="No bands match"):
+            cf_var.sel(pressure_level=900)
+
+    def test_slice_selector_is_rejected(self, cf_var):
+        """A range has no nearest value, so the combination is refused."""
+        with pytest.raises(ValueError, match="does not accept a slice"):
+            cf_var.sel(pressure_level=slice(500, 1000), method="nearest")
+
+    def test_date_label_is_rejected(self, cf_var):
+        """Snapping a date label is refused, pointing at exact label selection instead."""
+        with pytest.raises(ValueError, match="needs a numeric selector"):
+            cf_var.sel(time="2024-01-01", method="nearest")
+
+    def test_unknown_method_is_rejected(self, cf_var):
+        """Only ``None`` and ``"nearest"`` are accepted, and the error says so."""
+        with pytest.raises(ValueError, match="must be None \\(exact\\) or 'nearest'"):
+            cf_var.sel(pressure_level=850, method="pad")
+
+
+class TestSelByDateLabel:
+    """A CF time axis is selectable by the labels ``get_time_variable`` reports."""
+
+    def test_full_precision_label_pins_one_step(self, cf_var):
+        """A fully-qualified label selects the single step it names.
+
+        Test scenario:
+            ``sel(time="2024-01-01 12:00:00")`` on ``hours since 2024-01-01`` → offset 12.
+        """
+        result = cf_var.sel(time="2024-01-01 12:00:00")
+        assert result._band_dim_values_map["time"] == [12.0], (
+            f"got {result._band_dim_values_map['time']}"
+        )
+
+    def test_iso_spelling_is_accepted(self, cf_var):
+        """The ISO ``T`` separator and a trailing ``Z`` resolve the same as the plain form."""
+        result = cf_var.sel(time="2024-01-01T12:00:00Z")
+        assert result._band_dim_values_map["time"] == [12.0]
+
+    def test_partial_label_takes_the_whole_period(self, cf_var):
+        """A date-only label matches every step inside that day.
+
+        Test scenario:
+            The fixture's four steps all fall on 2024-01-01, so ``sel(time="2024-01-01")``
+            keeps the whole time axis.
+        """
+        result = cf_var.sel(time="2024-01-01")
+        assert result._band_dim_values_map["time"] == TIME_VALUES, (
+            f"got {result._band_dim_values_map['time']}"
+        )
+
+    def test_label_slice_is_inclusive(self, cf_var):
+        """A slice of labels takes an inclusive range of steps."""
+        result = cf_var.sel(time=slice("2024-01-01 06:00", "2024-01-01 12:00"))
+        assert result._band_dim_values_map["time"] == [6.0, 12.0], (
+            f"got {result._band_dim_values_map['time']}"
+        )
+
+    def test_list_of_labels_selects_each(self, cf_var):
+        """A list of labels selects every step it names, in axis order."""
+        result = cf_var.sel(time=["2024-01-01 18:00:00", "2024-01-01 00:00:00"])
+        assert result._band_dim_values_map["time"] == [0.0, 18.0]
+
+    def test_label_selection_reads_the_same_data_as_the_raw_offset(self, cf_var):
+        """Selecting by label and by stored offset return the same plane."""
+        by_label = cf_var.sel(time="2024-01-01 12:00:00").read_array()
+        by_offset = cf_var.sel(time=12).read_array()
+        assert_array_equal(by_label, by_offset, err_msg="label and offset must agree")
+
+    def test_stored_offsets_still_select(self, cf_var):
+        """The raw-offset vocabulary keeps working — labels are an addition, not a swap."""
+        result = cf_var.sel(time=18)
+        assert result._band_dim_values_map["time"] == [18.0]
+
+    def test_missing_label_reports_the_available_labels(self, cf_var):
+        """A label the axis lacks lists the axis' labels, not its raw offsets.
+
+        Test scenario:
+            The error a caller sees must be in the vocabulary they selected with.
+        """
+        with pytest.raises(
+            ValueError, match="Available values: \\['2024-01-01 00:00:00'"
+        ):
+            cf_var.sel(time="2025-06-01")
+
+    def test_axis_without_parseable_units_falls_back_to_stored_values(self, coards_var):
+        """An axis whose CF units do not parse has no labels, so the raw vocabulary answers.
+
+        Test scenario:
+            The COARDS fixture's ``units`` defeat the time parser, so a label selector
+            finds nothing and the error quotes the stored offsets.
+        """
+        with pytest.raises(ValueError, match="Available values: \\[17549208.0"):
+            coards_var.sel(time="2024-01-01")
+
+    def test_unsupported_label_precision_is_rejected(self, cf_var):
+        """A label at an unsupported precision raises rather than silently matching nothing."""
+        with pytest.raises(ValueError, match="Supported precisions"):
+            cf_var.sel(time="2024-01-01 06:0")
+
+
+class TestSelectorsMethodPlumbing:
+    """``Selectors.method`` reaches the same resolver the eager ``sel`` path uses."""
+
+    def test_default_is_exact(self):
+        """``Selectors`` keeps exact matching unless the caller asks for nearest."""
+        assert Selectors().method is None
+
+    def test_flat_band_index_snaps_with_nearest(self, cf_var):
+        """The lazy render path resolves a snapped selector to the same band as ``sel``.
+
+        Test scenario:
+            ``pressure_level=900`` with ``method="nearest"`` → the 850 hPa plane of the
+            first time step, which is flat band 1 of the ``(time=4, level=3)`` cube.
+        """
+        index = NetCDFPlot(cf_var)._flat_band_index(
+            cf_var, {"pressure_level": 900}, "nearest"
+        )
+        assert index == LEVEL_VALUES.index(850.0), f"got band {index}"
+
+    def test_flat_band_index_resolves_a_date_label(self, cf_var):
+        """The lazy render path resolves a date label, matching the documented plot example.
+
+        Test scenario:
+            ``time="2024-01-01 06:00:00"`` is time index 1, whose first band on a
+            ``(time=4, level=3)`` cube is 3.
+        """
+        index = NetCDFPlot(cf_var)._flat_band_index(
+            cf_var, {"time": "2024-01-01 06:00:00"}
+        )
+        assert index == len(LEVEL_VALUES), f"got band {index}"

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -254,3 +254,45 @@ class TestSelSelectorVocabularyFallback:
         """Passing ``method=None`` explicitly behaves exactly as omitting it."""
         result = cf_var.sel(pressure_level=850, method=None)
         assert result._band_dim_values_map["pressure_level"] == [850.0]
+
+
+class TestSelUndecodableCoordinateValues:
+    """A coordinate value the CF converter cannot decode must not abort the selection."""
+
+    def test_fill_value_in_the_time_axis_falls_back_to_stored_values(self, cf_var):
+        """A NaN in the time axis leaves the stored-value path working.
+
+        Test scenario:
+            ``_decode_time_labels`` converts each value outside its own guard, so a
+            ``_FillValue`` / NaN entry used to abort `sel` with "cannot convert float NaN
+            to integer". Selecting by stored offset must still work, and a label selector
+            must degrade to "no bands match" rather than crash.
+        """
+        holed = cf_var.copy()
+        holed._band_dim_values_map = dict(cf_var._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [0.0, float("nan"), 12.0, 18.0]
+        assert holed.sel(time=12.0)._band_dim_values_map["time"] == [12.0]
+        with pytest.raises(ValueError, match="No bands match"):
+            holed.sel(time="2024-01-01 12:00:00")
+
+    def test_string_valued_coordinates_still_match_exactly(self, cf_var):
+        """A coordinate variable holding date strings keeps matching as it did before.
+
+        Test scenario:
+            Some stores carry the dates as strings in the coordinate variable itself. The
+            axis then cannot be decoded from its offsets, so the selector has to fall
+            through to an exact string match against the stored values — the behaviour
+            this file's decoding must not take away.
+        """
+        stringy = cf_var.copy()
+        stringy._band_dim_values_map = dict(cf_var._band_dim_values_map)
+        stringy._band_dim_values_map["time"] = [
+            "2024-01-13",
+            "2024-01-14",
+            "2024-01-15",
+            "2024-01-16",
+        ]
+        result = stringy.sel(time="2024-01-15")
+        assert result._band_dim_values_map["time"] == ["2024-01-15"], (
+            f"got {result._band_dim_values_map['time']}"
+        )

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -25,6 +25,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from pyramids.netcdf._label_select import FULL_FORMAT
 from pyramids.netcdf._plot import NetCDFPlot
 from pyramids.netcdf.netcdf import NetCDF
 from pyramids.netcdf.plot_options import Selectors
@@ -257,41 +258,57 @@ class TestSelSelectorVocabularyFallback:
 
 
 class TestSelUndecodableCoordinateValues:
-    """A coordinate value the CF converter cannot decode must not abort the selection."""
+    """A coordinate value the CF converter cannot decode must not abort the selection.
 
-    def test_fill_value_in_the_time_axis_falls_back_to_stored_values(self, cf_var):
+    Each test builds its variable from a fresh container rather than copying the shared
+    fixture: a copy loses the back-reference the CF ``units`` are resolved through, so
+    the decoder would never be reached and the tests would pass without exercising
+    anything.
+    """
+
+    def test_fill_value_in_the_time_axis_falls_back_to_stored_values(self):
         """A NaN in the time axis leaves the stored-value path working.
 
         Test scenario:
             ``_decode_time_labels`` converts each value outside its own guard, so a
-            ``_FillValue`` / NaN entry used to abort `sel` with "cannot convert float NaN
-            to integer". Selecting by stored offset must still work, and a label selector
+            ``_FillValue`` / NaN entry aborted `sel` with "cannot convert float NaN to
+            integer". Selecting by stored offset must still work, and a label selector
             must degrade to "no bands match" rather than crash.
         """
-        holed = cf_var.copy()
-        holed._band_dim_values_map = dict(cf_var._band_dim_values_map)
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
         holed._band_dim_values_map["time"] = [0.0, float("nan"), 12.0, 18.0]
+        with pytest.raises(ValueError, match="cannot convert float NaN"):
+            holed._decode_time_labels(
+                "time", holed._band_dim_values_map["time"], FULL_FORMAT
+            )
         assert holed.sel(time=12.0)._band_dim_values_map["time"] == [12.0]
         with pytest.raises(ValueError, match="No bands match"):
             holed.sel(time="2024-01-01 12:00:00")
 
-    def test_string_valued_coordinates_still_match_exactly(self, cf_var):
+    def test_string_valued_coordinates_still_match_exactly(self):
         """A coordinate variable holding date strings keeps matching as it did before.
 
         Test scenario:
-            Some stores carry the dates as strings in the coordinate variable itself. The
-            axis then cannot be decoded from its offsets, so the selector has to fall
-            through to an exact string match against the stored values — the behaviour
-            this file's decoding must not take away.
+            Some stores carry the dates as strings in the coordinate variable while the
+            dimension still declares parseable CF units. Decoding those values raises
+            ("could not convert string to float"), so the selector has to fall through
+            to an exact string match — the behaviour this branch must not take away.
         """
-        stringy = cf_var.copy()
-        stringy._band_dim_values_map = dict(cf_var._band_dim_values_map)
+        nc = NetCDF.read_file(CF_PATH)
+        stringy = nc.get_variable("temperature")
+        stringy._band_dim_values_map = dict(stringy._band_dim_values_map)
         stringy._band_dim_values_map["time"] = [
             "2024-01-13",
             "2024-01-14",
             "2024-01-15",
             "2024-01-16",
         ]
+        with pytest.raises(ValueError, match="could not convert string to float"):
+            stringy._decode_time_labels(
+                "time", stringy._band_dim_values_map["time"], FULL_FORMAT
+            )
         result = stringy.sel(time="2024-01-15")
         assert result._band_dim_values_map["time"] == ["2024-01-15"], (
             f"got {result._band_dim_values_map['time']}"

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -401,3 +401,35 @@ class TestSelDecodesTheAxisOncePerPrecision:
         """A slice compares full-precision labels, so one pass answers it."""
         selector = slice("2024-01-01 00:00:00", "2024-01-01 12:00:00")
         assert self._count_decodes(monkeypatch, cf_var, selector) == 1
+
+
+class TestSelectionErrorMessages:
+    """What a failed selection tells the caller."""
+
+    def test_a_non_numeric_selector_is_not_called_a_date_label(self, cf_var):
+        """A string on an axis with no labels is reported as non-numeric, not as a date.
+
+        Test scenario:
+            ``pressure_level="850"`` with ``method="nearest"`` used to be told it was a
+            date label and advised about partial labels — nonsense for a pressure axis.
+        """
+        with pytest.raises(ValueError, match="is not a number"):
+            cf_var.sel(pressure_level="850", method="nearest")
+
+    def test_a_long_axis_is_elided_in_the_message(self):
+        """A miss on a long axis shows both ends and a count, not every value.
+
+        Test scenario:
+            The COARDS cube has 12 time steps; a 128k-step cloud axis would otherwise
+            put every decoded timestamp into the exception string.
+        """
+        var = NetCDF.read_file(COARDS_PATH).get_variable("rhum")
+        with pytest.raises(ValueError, match=r"\.\.\..*\(12 values\)"):
+            var.sel(time=-1)
+
+    def test_a_short_axis_is_listed_in_full(self, cf_var):
+        """A short axis still lists every value — eliding only pays off when there are many."""
+        with pytest.raises(
+            ValueError, match=r"Available values: \[1000.0, 850.0, 500.0\]"
+        ):
+            cf_var.sel(pressure_level=999)

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -287,6 +287,74 @@ class TestSelUndecodableCoordinateValues:
         with pytest.raises(ValueError, match="No bands match"):
             holed.sel(time="2024-01-01 12:00:00")
 
+    @pytest.mark.parametrize(
+        ("hole", "raises"),
+        [
+            (9.96920996839e36, OverflowError),
+            (-9.9e36, OverflowError),
+            (float("inf"), OverflowError),
+            (float("nan"), ValueError),
+        ],
+        ids=["default-fill", "negative-fill", "infinity", "nan"],
+    )
+    def test_every_undecodable_value_shape_degrades(self, hole, raises):
+        """Whatever way the converter fails, the selection degrades instead of aborting.
+
+        Test scenario:
+            netCDF's default float `_FillValue` and an infinity raise `OverflowError`,
+            not the `ValueError` a NaN raises — and a `_FillValue` reaches a coordinate
+            as the raw sentinel unless something masks it first, so it is the likelier
+            shape of the two.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [0.0, hole, 12.0, 18.0]
+        with pytest.raises(raises):
+            holed._decode_time_labels(
+                "time", holed._band_dim_values_map["time"], FULL_FORMAT
+            )
+        assert holed.sel(time=12.0)._band_dim_values_map["time"] == [12.0]
+        with pytest.raises(ValueError, match="No bands match"):
+            holed.sel(time="2024-01-01 12:00:00")
+
+    def test_the_lazy_render_path_degrades_too(self):
+        """`_flat_band_index` resolves through the same guard, so it cannot crash either.
+
+        Test scenario:
+            Both render paths reach `_resolve_selector_indices`; only `sel` was covered.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [0.0, 9.96920996839e36, 12.0, 18.0]
+        index = NetCDFPlot(holed)._flat_band_index(
+            holed, {"time": "2024-01-01 12:00:00", "pressure_level": 850.0}
+        )
+        assert isinstance(index, int), f"got {index!r}"
+
+    def test_a_label_slice_on_an_undecodable_axis_finds_nothing(self):
+        """A label slice degrades like a scalar rather than comparing str against float.
+
+        Test scenario:
+            The stored-value fallback compares the slice bounds against the coordinates,
+            so a string-bounded slice over a numeric axis raised
+            `TypeError: '<=' not supported between instances of 'str' and 'float'` —
+            outside the `ValueError` contract `sel` documents, and where the scalar and
+            list forms both degraded correctly.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [0.0, float("nan"), 12.0, 18.0]
+        with pytest.raises(ValueError, match="No bands match"):
+            holed.sel(time=slice("2024-01-01", "2024-01-02"))
+
+    def test_a_string_slice_on_a_numeric_axis_finds_nothing(self, cf_var):
+        """The same holds for an axis that was never a time axis at all."""
+        with pytest.raises(ValueError, match="No bands match"):
+            cf_var.sel(pressure_level=slice("500", "1000"))
+
     def test_string_valued_coordinates_still_match_exactly(self):
         """A coordinate variable holding date strings keeps matching as it did before.
 

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -540,3 +540,20 @@ class TestSelectionErrorMessages:
             ValueError, match=r"Available values: \[1000.0, 850.0, 500.0\]"
         ):
             cf_var.sel(pressure_level=999)
+
+    def test_the_hint_survives_a_hole_in_the_first_coordinate(self):
+        """The explanation is reached even when the probed coordinate is the bad one.
+
+        Test scenario:
+            The hint probes one value to tell "no CF units" apart from "units, but a
+            value would not decode". When that value is itself the hole, the probe
+            raises, which still means the axis declares units.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [float("nan"), 6.0, 12.0, 18.0]
+        with pytest.raises(
+            ValueError, match="declares CF units, but a coordinate value"
+        ):
+            holed.sel(time="2024-01-01 12:00:00")

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -501,16 +501,38 @@ class TestSelectionErrorMessages:
         with pytest.raises(ValueError, match="is not a number"):
             cf_var.sel(pressure_level="850", method="nearest")
 
-    def test_a_long_axis_is_elided_in_the_message(self):
-        """A miss on a long axis shows both ends and a count, not every value.
+    def test_a_twelve_step_axis_is_listed_in_full(self):
+        """A monthly axis is short enough to print, and its values are what fixes a typo.
 
         Test scenario:
-            The COARDS cube has 12 time steps; a 128k-step cloud axis would otherwise
-            put every decoded timestamp into the exception string.
+            Eliding is aimed at a 128k-step cloud axis; a 12-step one is the shape of a
+            great many real files, and cutting six of its values helps nobody.
         """
         var = NetCDF.read_file(COARDS_PATH).get_variable("rhum")
-        with pytest.raises(ValueError, match=r"\.\.\..*\(12 values\)"):
+        with pytest.raises(ValueError, match=r"17549208.0.*17549472.0"):
             var.sel(time=-1)
+
+    def test_an_undecodable_axis_says_why_the_label_missed(self):
+        """A label that misses because the axis would not decode is told so.
+
+        Test scenario:
+            The axis declares CF units, so being shown raw offsets with no explanation
+            invites the wrong conclusion — that it is not a time axis at all.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        holed = nc.get_variable("temperature")
+        holed._band_dim_values_map = dict(holed._band_dim_values_map)
+        holed._band_dim_values_map["time"] = [0.0, float("nan"), 12.0, 18.0]
+        with pytest.raises(
+            ValueError, match="declares CF units, but a coordinate value"
+        ):
+            holed.sel(time="2024-01-01 12:00:00")
+
+    def test_an_axis_with_no_units_gets_no_such_hint(self, cf_var):
+        """An axis that simply has no CF units is not accused of a decode failure."""
+        with pytest.raises(ValueError) as excinfo:
+            cf_var.sel(pressure_level=999)
+        assert "declares CF units" not in str(excinfo.value), str(excinfo.value)
 
     def test_a_short_axis_is_listed_in_full(self, cf_var):
         """A short axis still lists every value — eliding only pays off when there are many."""

--- a/tests/netcdf/selection/test_sel_nearest_and_labels.py
+++ b/tests/netcdf/selection/test_sel_nearest_and_labels.py
@@ -296,3 +296,38 @@ class TestSelUndecodableCoordinateValues:
         assert result._band_dim_values_map["time"] == ["2024-01-15"], (
             f"got {result._band_dim_values_map['time']}"
         )
+
+
+class TestGetTimeVariableRoundTrip:
+    """A label handed back by ``get_time_variable`` selects the period it names."""
+
+    def test_default_format_label_selects_the_whole_day(self):
+        """``get_time_variable()``'s default label is date-only, so it keeps every step that day.
+
+        Test scenario:
+            The documented round-trip has to say which precision it round-trips at —
+            ``"%Y-%m-%d"`` is a day, and on this 6-hourly fixture that is four steps.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        var = nc.get_variable("temperature")
+        label = nc.get_time_variable("time")[1]
+        assert label == "2024-01-01", f"got {label!r}"
+        assert var.sel(time=label)._band_dim_values_map["time"] == TIME_VALUES
+
+    def test_full_precision_format_label_pins_one_step(self):
+        """Asking ``get_time_variable`` for the finer format gives labels that pin one step."""
+        nc = NetCDF.read_file(CF_PATH)
+        var = nc.get_variable("temperature")
+        labels = nc.get_time_variable("time", "%Y-%m-%d %H:%M:%S")
+        assert labels[1] == "2024-01-01 06:00:00", f"got {labels[1]!r}"
+        assert var.sel(time=labels[1])._band_dim_values_map["time"] == [6.0]
+
+    def test_every_full_precision_label_round_trips_to_its_own_step(self):
+        """Each finer-format label selects exactly the offset it was decoded from."""
+        nc = NetCDF.read_file(CF_PATH)
+        var = nc.get_variable("temperature")
+        labels = nc.get_time_variable("time", "%Y-%m-%d %H:%M:%S")
+        for label, offset in zip(labels, TIME_VALUES, strict=True):
+            assert var.sel(time=label)._band_dim_values_map["time"] == [offset], (
+                f"{label!r} should select {offset}"
+            )

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -27,6 +27,7 @@ pytestmark = pytest.mark.core
 
 COARDS_PATH = "tests/data/netcdf/coards__5v__1d4-4d1__y-desc.nc"
 CF_PATH = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+WRF_PATH = "tests/data/netcdf/none__17v__1d1-2d5-3d6-4d5__stag-str.nc"
 
 LEVELS = [1000.0, 925.0, 850.0, 700.0]
 
@@ -179,3 +180,35 @@ class TestInMemoryContainer:
             dims=ExtraDimensions(name="time", values=[0, 6, 12, 18, 24]),
         )
         assert nc.get_variable("temp").get_dimension_values("missing") is None
+
+
+class TestStringTypedCoordinateVariable:
+    """A character coordinate axis (WRF ``Times``) reads rather than raising."""
+
+    def test_container_reads_the_real_timestamps(self):
+        """The container reports the stored strings, matching the xarray bridge.
+
+        Test scenario:
+            `ReadAsArray` refuses a character MDArray in the SWIG bindings, so the
+            accessor used to surface a raw `RuntimeError: String buffer data type not
+            supported`. The list-based read that `to_xarray` uses handles it.
+        """
+        nc = NetCDF.read_file(WRF_PATH)
+        values = nc.get_dimension_values("Time")
+        assert list(values) == [
+            "2000-01-24_12:00:00",
+            "2000-01-24_13:00:00",
+            "2000-01-24_14:00:00",
+        ], f"got {values!r}"
+
+    def test_a_subset_reports_the_tracked_placeholder(self):
+        """A variable subset answers with the integer placeholder it tracks, documented as such.
+
+        Test scenario:
+            The subset build cannot read a string indexing variable either, and records
+            `[0, 1, ...]`. `sel` matches against those same integers, so the accessor and
+            the selector agree — the Returns section says they are not the file's labels.
+        """
+        nc = NetCDF.read_file(WRF_PATH)
+        var = nc.get_variable("IVGTYP")
+        assert list(var.get_dimension_values("Time")) == [0, 1, 2]

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -59,8 +59,14 @@ class TestRootContainer:
             err_msg="level coordinates should come straight off the container",
         )
 
-    def test_every_declared_dimension_is_reachable(self, coards_nc):
-        """Each name in ``dimension_sizes`` resolves to an array of that length."""
+    def test_each_coards_dimension_resolves_to_its_declared_length(self, coards_nc):
+        """Every dimension of *this* fixture resolves to an array of the declared length.
+
+        Test scenario:
+            Not a general guarantee — a dimension with no indexing variable correctly
+            answers ``None`` (the WRF fixture has eight of them). This one carries a
+            coordinate variable for each of its four dimensions.
+        """
         for name, size in coards_nc.dimension_sizes.items():
             values = coards_nc.get_dimension_values(name)
             assert values is not None, f"{name!r} declared but has no coordinates"

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from pyramids.netcdf import ExtraDimensions, GeoReference
 from pyramids.netcdf.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
@@ -116,3 +117,38 @@ class TestGetTimeValuesDelegation:
     def test_absent_axis_is_none(self, coards_nc):
         """Asking for an axis the store has no dimension for still answers ``None``."""
         assert coards_nc.get_time_values("valid_time") is None
+
+
+class TestInMemoryContainer:
+    """A cube built with ``from_array`` answers for the dimension it declares."""
+
+    def test_extra_dimension_values_are_readable(self):
+        """A band dim declared through ``ExtraDimensions`` is readable on both views.
+
+        Test scenario:
+            The accessor must not depend on an on-disk MDIM root group — an in-memory
+            container and the variable it yields report the same coordinates.
+        """
+        arr = np.arange(60, dtype=np.float64).reshape(5, 3, 4)
+        nc = NetCDF.from_array(
+            arr=arr,
+            geo_ref=GeoReference(geo=(0.0, 1.0, 0, 3.0, 0, -1.0)),
+            variable_name="temp",
+            dims=ExtraDimensions(name="time", values=[0, 6, 12, 18, 24]),
+        )
+        expected = np.array([0, 6, 12, 18, 24])
+        assert_array_equal(nc.get_dimension_values("time"), expected)
+        assert_array_equal(
+            nc.get_variable("temp").get_dimension_values("time"), expected
+        )
+
+    def test_unknown_name_on_a_subset_is_none(self):
+        """A subset asked for a name it neither tracks nor declares answers ``None``."""
+        arr = np.arange(60, dtype=np.float64).reshape(5, 3, 4)
+        nc = NetCDF.from_array(
+            arr=arr,
+            geo_ref=GeoReference(geo=(0.0, 1.0, 0, 3.0, 0, -1.0)),
+            variable_name="temp",
+            dims=ExtraDimensions(name="time", values=[0, 6, 12, 18, 24]),
+        )
+        assert nc.get_variable("temp").get_dimension_values("missing") is None

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -100,11 +100,19 @@ class TestRootContainer:
         assert coards_nc.get_dimension_values("depth") is None
 
     def test_time_axis_reports_stored_offsets(self, coards_nc):
-        """The values are the stored ones, matching what ``sel`` matches against."""
+        """The time axis comes back as the raw CF offsets the file stores.
+
+        Test scenario:
+            Compared against the underlying read rather than against `get_time_values`,
+            which now delegates here — that comparison could not fail.
+        """
         assert_array_equal(
             coards_nc.get_dimension_values("time"),
-            coards_nc.get_time_values("time"),
-            err_msg="get_time_values is the time-axis spelling of this accessor",
+            coards_nc._read_variable("time"),
+            err_msg="the accessor should hand back the stored coordinate variable",
+        )
+        assert coards_nc.get_time_variable("time") is None, (
+            "this fixture's units do not parse — the raw offsets are all there is"
         )
 
 

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -209,14 +209,27 @@ class TestStringTypedCoordinateVariable:
             "2000-01-24_14:00:00",
         ], f"got {values!r}"
 
-    def test_a_subset_reports_the_tracked_placeholder(self):
-        """A variable subset answers with the integer placeholder it tracks, documented as such.
+    def test_a_subset_agrees_with_its_container(self):
+        """A subset reports the same timestamps its container does, not integer indices.
 
         Test scenario:
-            The subset build cannot read a string indexing variable either, and records
-            `[0, 1, ...]`. `sel` matches against those same integers, so the accessor and
-            the selector agree — the Returns section says they are not the file's labels.
+            The subset build hit the same SWIG refusal and recorded `[0, 1, 2]`, so one
+            file answered two different vocabularies for one dimension depending on which
+            object was asked — and `sel(Time=<timestamp>)` found nothing.
         """
         nc = NetCDF.read_file(WRF_PATH)
         var = nc.get_variable("IVGTYP")
-        assert list(var.get_dimension_values("Time")) == [0, 1, 2]
+        stamps = [
+            "2000-01-24_12:00:00",
+            "2000-01-24_13:00:00",
+            "2000-01-24_14:00:00",
+        ]
+        assert list(var.get_dimension_values("Time")) == stamps
+        assert list(nc.get_dimension_values("Time")) == stamps
+
+    def test_a_subset_selects_by_that_timestamp(self):
+        """The coordinates a subset reports are the ones `sel` matches against."""
+        nc = NetCDF.read_file(WRF_PATH)
+        var = nc.get_variable("IVGTYP")
+        pinned = var.sel(Time="2000-01-24_13:00:00")
+        assert list(pinned.get_dimension_values("Time")) == ["2000-01-24_13:00:00"]

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -67,6 +67,33 @@ class TestRootContainer:
                 f"{name!r}: {len(values)} values for size {size}"
             )
 
+    def test_spatial_coordinates_come_back_in_storage_order(self):
+        """A 1-D spatial axis reports what the file stores, not the raster's row order.
+
+        Test scenario:
+            The y-ascending fixture stores latitudes south-to-north while pyramids
+            presents the raster north-up, so the accessor and `read_array`'s rows run
+            opposite ways. That is the documented contract — it matches `sel` and
+            `to_xarray().coords` — and this pins it against a silent flip.
+        """
+        nc = NetCDF.read_file(CF_PATH)
+        lats = nc.get_dimension_values("lat")
+        assert lats[0] < lats[-1], f"y-asc file should report ascending, got {lats}"
+        gt = nc.get_variable("temperature").geotransform
+        rows = NetCDF.get_y_lat_dimension_array(
+            gt[3], abs(gt[5]), nc.get_variable("temperature").rows
+        )
+        assert_array_equal(
+            np.asarray(rows),
+            lats[::-1],
+            err_msg="the raster row centres should be the reverse of the stored axis here",
+        )
+
+    def test_a_y_descending_file_reports_descending(self, coards_nc):
+        """On a north-to-south file storage order and raster order already agree."""
+        lats = coards_nc.get_dimension_values("lat")
+        assert lats[0] > lats[-1], f"y-desc file should report descending, got {lats}"
+
     def test_unknown_dimension_is_none(self, coards_nc):
         """A name the dataset does not declare answers ``None`` rather than raising."""
         assert coards_nc.get_dimension_values("depth") is None

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -1,0 +1,118 @@
+"""Tests for ``NetCDF.get_dimension_values`` — the coordinate accessor (issue #1125).
+
+``time`` had ``get_time_values`` / ``get_time_variable`` and the spatial axes come off
+the geotransform, but a non-spatial, non-time axis (``level``, ``depth``, ``member``)
+had no native accessor: its values were reachable only through the optional
+``to_xarray`` bridge or by provoking ``sel``'s "Available values" error.
+
+Fixtures:
+- ``tests/data/netcdf/coards__5v__1d4-4d1__y-desc.nc`` — ``(time=12, level=4, lat, lon)``
+  with levels ``[1000, 925, 850, 700]``.
+- ``tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc`` — synthetic 4-D CF cube.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports,
+descriptive assertion messages.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from pyramids.netcdf.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+COARDS_PATH = "tests/data/netcdf/coards__5v__1d4-4d1__y-desc.nc"
+CF_PATH = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+
+LEVELS = [1000.0, 925.0, 850.0, 700.0]
+
+
+@pytest.fixture(scope="module")
+def coards_nc() -> NetCDF:
+    """The COARDS root container, which declares a 4-level vertical axis."""
+    return NetCDF.read_file(COARDS_PATH)
+
+
+@pytest.fixture(scope="module")
+def coards_var(coards_nc) -> NetCDF:
+    """The ``rhum`` variable subset of that container."""
+    return coards_nc.get_variable("rhum")
+
+
+class TestRootContainer:
+    """A root container answers for any dimension it declares."""
+
+    def test_reads_a_non_spatial_coordinate(self, coards_nc):
+        """The vertical axis' values are readable without the xarray bridge.
+
+        Test scenario:
+            ``get_dimension_values("level")`` → ``[1000., 925., 850., 700.]``.
+        """
+        assert_array_equal(
+            coards_nc.get_dimension_values("level"),
+            np.array(LEVELS),
+            err_msg="level coordinates should come straight off the container",
+        )
+
+    def test_every_declared_dimension_is_reachable(self, coards_nc):
+        """Each name in ``dimension_sizes`` resolves to an array of that length."""
+        for name, size in coards_nc.dimension_sizes.items():
+            values = coards_nc.get_dimension_values(name)
+            assert values is not None, f"{name!r} declared but has no coordinates"
+            assert len(values) == size, (
+                f"{name!r}: {len(values)} values for size {size}"
+            )
+
+    def test_unknown_dimension_is_none(self, coards_nc):
+        """A name the dataset does not declare answers ``None`` rather than raising."""
+        assert coards_nc.get_dimension_values("depth") is None
+
+    def test_time_axis_reports_stored_offsets(self, coards_nc):
+        """The values are the stored ones, matching what ``sel`` matches against."""
+        assert_array_equal(
+            coards_nc.get_dimension_values("time"),
+            coards_nc.get_time_values("time"),
+            err_msg="get_time_values is the time-axis spelling of this accessor",
+        )
+
+
+class TestVariableSubset:
+    """A variable subset answers from the band-dim coordinates it carries."""
+
+    def test_band_dimension_is_readable(self, coards_var):
+        """A subset reports its own band-dim coordinates."""
+        assert_array_equal(coards_var.get_dimension_values("level"), np.array(LEVELS))
+
+    def test_reflects_what_the_view_holds_after_sel(self, coards_var):
+        """After a ``sel`` the accessor reports the values that view actually holds.
+
+        Test scenario:
+            This is how a ``method="nearest"`` caller reads back the coordinate that
+            was snapped to.
+        """
+        pinned = coards_var.sel(level=850)
+        assert_array_equal(
+            pinned.get_dimension_values("level"),
+            np.array([850.0]),
+            err_msg="a pinned view should report only the level it kept",
+        )
+
+    def test_spatial_axis_has_no_coordinate_variable(self, coards_var):
+        """A subset does not track its spatial axes, so they answer ``None``."""
+        assert coards_var.get_dimension_values("lat") is None
+
+
+class TestGetTimeValuesDelegation:
+    """``get_time_values`` keeps its contract now that it delegates here."""
+
+    def test_named_axis_still_reads(self):
+        """The documented call still returns the raw offsets of the named axis."""
+        nc = NetCDF.read_file(CF_PATH)
+        assert_array_equal(nc.get_time_values("time"), np.array([0.0, 6.0, 12.0, 18.0]))
+
+    def test_absent_axis_is_none(self, coards_nc):
+        """Asking for an axis the store has no dimension for still answers ``None``."""
+        assert coards_nc.get_time_values("valid_time") is None

--- a/tests/netcdf/structure/test_dimension_values.py
+++ b/tests/netcdf/structure/test_dimension_values.py
@@ -239,3 +239,24 @@ class TestStringTypedCoordinateVariable:
         var = nc.get_variable("IVGTYP")
         pinned = var.sel(Time="2000-01-24_13:00:00")
         assert list(pinned.get_dimension_values("Time")) == ["2000-01-24_13:00:00"]
+
+
+class TestUnreadableIndexingVariable:
+    """When neither read works, the subset falls back to integer indices."""
+
+    def test_the_placeholder_is_the_last_resort(self, monkeypatch):
+        """A coordinate variable no read can handle still yields a usable axis.
+
+        Test scenario:
+            `ReadAsArray` already refuses this WRF `Times` axis; with the list-based
+            read stubbed out to fail too, the build must not raise — it records
+            `[0, 1, ..., size - 1]`, which is what `sel` then matches against.
+        """
+
+        def refuse(_md_array):
+            raise RuntimeError("no read path available")
+
+        monkeypatch.setattr(NetCDF, "_md_array_to_numpy", staticmethod(refuse))
+        nc = NetCDF.read_file(WRF_PATH)
+        var = nc.get_variable("IVGTYP")
+        assert list(var.get_dimension_values("Time")) == [0, 1, 2]

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -245,3 +245,19 @@ class TestNearestIndices:
         """A NaN or infinite request has no nearest coordinate."""
         with pytest.raises(ValueError, match="finite selector values"):
             nearest_indices([1000.0, 850.0], float("nan"))
+
+    @pytest.mark.parametrize(
+        "axis",
+        [[700.0, 850.0, 925.0, 1000.0], [1000.0, 925.0, 850.0, 700.0]],
+        ids=["ascending", "descending"],
+    )
+    def test_a_tie_resolves_to_the_same_coordinate_either_direction(self, axis):
+        """An exact midpoint snaps to the smaller coordinate whichever way the axis is stored.
+
+        Test scenario:
+            887.5 is equidistant from 850 and 925. Taking the lowest *index* made the
+            answer depend on storage order — 850 on an ascending file, 925 on a
+            descending one — for the same physical request.
+        """
+        index = nearest_indices(axis, 887.5)[0]
+        assert axis[index] == 850.0, f"tie resolved to {axis[index]}"

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -179,6 +179,17 @@ class TestLabelIndices:
         """A label the axis does not carry matches nothing rather than raising."""
         assert label_indices(_decode, "2025-01-01") == []
 
+    def test_an_empty_axis_matches_nothing_rather_than_raising(self):
+        """A slice against an axis with no decoded labels answers empty.
+
+        Test scenario:
+            The open-bound path takes `min(labels)` / `max(labels)`, which used to raise
+            a bare "min() iterable argument is empty" on an axis the caller had not
+            pre-checked.
+        """
+        assert label_indices(lambda fmt: [], slice(None, None)) == []
+        assert label_indices(lambda fmt: [], "2024-01-01") == []
+
 
 class TestNearestIndices:
     """``method="nearest"`` snaps a numeric request to the closest coordinate."""

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -296,6 +296,20 @@ class TestLabelShapeRecognition:
         """Every supported precision still resolves to its format."""
         assert probe_format(text) is not None, f"{text!r} should read as a date label"
 
+    @pytest.mark.parametrize(
+        "selector",
+        [slice("control", "x"), slice("850", "1000"), ["control", "x"]],
+    )
+    def test_a_non_date_container_is_not_a_label_selection(self, selector):
+        """The shape test governs lists and slices, not only scalars.
+
+        Test scenario:
+            The slice arm short-circuited to the full format before consulting the
+            shape, so `slice("control", "x")` read as a date range and failed deep
+            inside the padding instead of matching stored values.
+        """
+        assert probe_format(selector) is None, f"{selector!r} should not read as labels"
+
     @pytest.mark.parametrize("selector", [850.0, [1000.0, 850.0], slice(500, 1000)])
     def test_a_selector_with_no_string_has_no_probe_format(self, selector):
         """A purely numeric selector needs no decode, so it resolves no format.

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -296,6 +296,16 @@ class TestLabelShapeRecognition:
         """Every supported precision still resolves to its format."""
         assert probe_format(text) is not None, f"{text!r} should read as a date label"
 
+    @pytest.mark.parametrize("selector", [850.0, [1000.0, 850.0], slice(500, 1000)])
+    def test_a_selector_with_no_string_has_no_probe_format(self, selector):
+        """A purely numeric selector needs no decode, so it resolves no format.
+
+        Test scenario:
+            The engine only probes a selector `has_label` accepted, but the primitive is
+            shared and doctested, so it has to answer for a numeric one too.
+        """
+        assert probe_format(selector) is None
+
     def test_a_non_date_string_is_rejected_by_label_format(self):
         """``label_format`` refuses it too, so the two agree on what a label is."""
         with pytest.raises(ValueError, match="not a supported date label"):

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -1,0 +1,227 @@
+"""Unit tests for the label / nearest matching primitives behind ``NetCDF.sel``.
+
+Pure functions over a synthetic axis — no GDAL, no fixtures. The end-to-end
+behaviour on a real file lives in
+``tests/netcdf/selection/test_sel_nearest_and_labels.py``.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports,
+descriptive assertion messages.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+
+from pyramids.netcdf._label_select import (
+    FULL_FORMAT,
+    has_label,
+    label_format,
+    label_indices,
+    nearest_indices,
+    normalise_label,
+    pad_label,
+)
+
+pytestmark = pytest.mark.core
+
+LEVELS = [1000.0, 925.0, 850.0, 700.0]
+STEPS = [datetime(2024, 1, 1) + timedelta(hours=hours) for hours in (0, 6, 12, 18)]
+
+
+def _decode(fmt: str) -> list[str]:
+    """Decode the synthetic 6-hourly axis at ``fmt`` — stands in for the CF decoder."""
+    return [step.strftime(fmt) for step in STEPS]
+
+
+class TestNormaliseLabel:
+    """A label is accepted in the ISO spellings a user is likely to paste."""
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [
+            ("2024-01-01T06:00:00Z", "2024-01-01 06:00:00"),
+            ("2024-01-01T06:00:00", "2024-01-01 06:00:00"),
+            ("  2024-01-01 06:00:00  ", "2024-01-01 06:00:00"),
+            ("2024-01", "2024-01"),
+        ],
+    )
+    def test_spellings_collapse_to_one_form(self, given: str, expected: str):
+        """Every accepted spelling normalises to the space-separated, zone-free form.
+
+        Test scenario:
+            The ISO ``T`` separator, a trailing ``Z``, and surrounding whitespace are
+            all removed; a partial label is otherwise untouched.
+        """
+        assert normalise_label(given) == expected, (
+            f"{given!r} -> {normalise_label(given)!r}"
+        )
+
+
+class TestLabelFormat:
+    """A label's length picks the strftime format that decodes the axis to match it."""
+
+    @pytest.mark.parametrize(
+        ("label", "fmt"),
+        [
+            ("2024", "%Y"),
+            ("2024-01", "%Y-%m"),
+            ("2024-01-01", "%Y-%m-%d"),
+            ("2024-01-01 06", "%Y-%m-%d %H"),
+            ("2024-01-01 06:00", "%Y-%m-%d %H:%M"),
+            ("2024-01-01 06:00:00", FULL_FORMAT),
+        ],
+    )
+    def test_each_precision_maps_to_its_format(self, label: str, fmt: str):
+        """Each supported precision maps to the format decoding the axis at that precision."""
+        assert label_format(label) == fmt, f"{label!r} -> {label_format(label)!r}"
+
+    def test_unsupported_precision_is_rejected(self):
+        """A label of an unsupported length raises, listing the precisions that work.
+
+        Test scenario:
+            ``"2024-01-01 06:0"`` sits between two supported precisions.
+        """
+        with pytest.raises(ValueError, match="Supported precisions"):
+            label_format("2024-01-01 06:0")
+
+
+class TestPadLabel:
+    """A partial label names a period, so it pads to that period's first or last instant."""
+
+    @pytest.mark.parametrize(
+        ("label", "lower", "upper"),
+        [
+            ("2024", "2024-01-01 00:00:00", "2024-12-31 23:59:59"),
+            ("2024-06", "2024-06-01 00:00:00", "2024-06-31 23:59:59"),
+            ("2024-06-15", "2024-06-15 00:00:00", "2024-06-15 23:59:59"),
+        ],
+    )
+    def test_bounds_cover_the_whole_period(self, label: str, lower: str, upper: str):
+        """The lower bound is the period's first instant, the upper its last.
+
+        Test scenario:
+            The upper template pads to day 31 whatever the month's length — it is only
+            ever compared as text, and no real label for that month sorts above it.
+        """
+        assert pad_label(label, upper=False) == lower, f"lower of {label!r}"
+        assert pad_label(label, upper=True) == upper, f"upper of {label!r}"
+
+
+class TestHasLabel:
+    """A selector carrying a string selects by label; anything else by stored value."""
+
+    @pytest.mark.parametrize(
+        ("selector", "expected"),
+        [
+            ("2024-01-01", True),
+            (["2024-01-01", "2024-01-02"], True),
+            (slice("2024-01-01", None), True),
+            (slice(None, "2024-01-01"), True),
+            (850.0, False),
+            ([1000.0, 850.0], False),
+            (slice(500, 1000), False),
+            (slice(None, None), False),
+        ],
+    )
+    def test_string_anywhere_means_label_selection(self, selector, expected: bool):
+        """A string anywhere in the selector flags it as a label selection."""
+        assert has_label(selector) is expected, f"{selector!r} -> {has_label(selector)}"
+
+
+class TestLabelIndices:
+    """A label matches at its own precision, so a partial one takes a whole period."""
+
+    def test_full_precision_label_matches_one_step(self):
+        """A fully-qualified label pins a single step."""
+        assert label_indices(_decode, "2024-01-01 12:00:00") == [2]
+
+    def test_date_only_label_matches_every_step_that_day(self):
+        """A date-only label matches every step inside that day, as xarray's partial indexing does."""
+        assert label_indices(_decode, "2024-01-01") == [0, 1, 2, 3]
+
+    def test_year_label_matches_the_whole_year(self):
+        """A year-only label matches the whole axis when it all falls in that year."""
+        assert label_indices(_decode, "2024") == [0, 1, 2, 3]
+
+    def test_list_unions_its_labels_in_axis_order(self):
+        """A list of labels unions their matches and reports them in ascending axis order."""
+        selector = ["2024-01-01 18:00:00", "2024-01-01 00:00:00"]
+        assert label_indices(_decode, selector) == [0, 3], (
+            "union should be axis-ordered"
+        )
+
+    def test_list_may_mix_precisions(self):
+        """Each label in a list is matched at its own precision, so mixing them is fine."""
+        selector = ["2024-01-01 06", "2024-01-01 12:00:00"]
+        assert label_indices(_decode, selector) == [1, 2]
+
+    def test_slice_bounds_are_inclusive(self):
+        """A label slice takes an inclusive range, padding each bound to its period edge."""
+        assert label_indices(
+            _decode, slice("2024-01-01 06:00", "2024-01-01 12:00")
+        ) == [1, 2]
+
+    def test_open_slice_runs_to_the_axis_end(self):
+        """An open bound runs to the corresponding end of the axis."""
+        assert label_indices(_decode, slice("2024-01-01 12:00:00", None)) == [2, 3]
+        assert label_indices(_decode, slice(None, "2024-01-01 06:00:00")) == [0, 1]
+
+    def test_reversed_slice_bounds_are_normalised(self):
+        """Bounds given newest-first still select the range, matching the stored-value path."""
+        reversed_bounds = slice("2024-01-01 12:00", "2024-01-01 06:00")
+        assert label_indices(_decode, reversed_bounds) == [1, 2]
+
+    def test_label_outside_the_axis_matches_nothing(self):
+        """A label the axis does not carry matches nothing rather than raising."""
+        assert label_indices(_decode, "2025-01-01") == []
+
+
+class TestNearestIndices:
+    """``method="nearest"`` snaps a numeric request to the closest coordinate."""
+
+    def test_snaps_to_the_closer_neighbour(self):
+        """A value between two coordinates snaps to the closer one."""
+        assert nearest_indices(LEVELS, 900.0) == [1], "900 is closer to 925 than to 850"
+
+    def test_exact_value_snaps_to_itself(self):
+        """A value already on the axis snaps to itself."""
+        assert nearest_indices(LEVELS, 925.0) == [1]
+
+    def test_out_of_range_value_snaps_to_the_end(self):
+        """A value beyond either end snaps to that end rather than failing."""
+        assert nearest_indices(LEVELS, 10.0) == [3], (
+            "below the axis -> its lowest level"
+        )
+        assert nearest_indices(LEVELS, 5000.0) == [0], (
+            "above the axis -> its highest level"
+        )
+
+    def test_each_value_in_a_list_snaps_independently(self):
+        """Every value in a list snaps on its own, and the result is axis-ordered."""
+        assert nearest_indices(LEVELS, [990.0, 710.0]) == [0, 3]
+
+    def test_collisions_are_deduplicated(self):
+        """Two requests snapping to the same coordinate yield one index."""
+        assert nearest_indices(LEVELS, [995.0, 1005.0]) == [0]
+
+    def test_numpy_scalars_are_numeric(self):
+        """A numpy scalar off a coordinate array counts as numeric."""
+        assert nearest_indices(list(np.array(LEVELS)), np.float64(900.0)) == [1]
+
+    def test_slice_is_rejected(self):
+        """A slice has no nearest value, so it is rejected with a pointer to the fix."""
+        with pytest.raises(ValueError, match="does not accept a slice"):
+            nearest_indices(LEVELS, slice(700, 1000))
+
+    def test_non_numeric_selector_is_rejected(self):
+        """A non-numeric selector cannot be snapped."""
+        with pytest.raises(ValueError, match="numeric selector values"):
+            nearest_indices(LEVELS, "850")
+
+    def test_non_numeric_axis_is_rejected(self):
+        """An axis of non-numeric coordinates cannot be snapped against."""
+        with pytest.raises(ValueError, match="numeric coordinate axis"):
+            nearest_indices(["a", "b"], 1.0)

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -23,6 +23,7 @@ from pyramids.netcdf._label_select import (
     nearest_indices,
     normalise_label,
     pad_label,
+    probe_format,
 )
 
 pytestmark = pytest.mark.core
@@ -261,3 +262,30 @@ class TestNearestIndices:
         """
         index = nearest_indices(axis, 887.5)[0]
         assert axis[index] == 850.0, f"tie resolved to {axis[index]}"
+
+
+class TestLabelShapeRecognition:
+    """A label is recognised by its shape, so an arbitrary string is a stored value."""
+
+    @pytest.mark.parametrize("text", ["control", "member01", "hi", "20240101"])
+    def test_a_non_date_string_is_not_a_label(self, text: str):
+        """A string that is not shaped like a date resolves no probe format.
+
+        Test scenario:
+            ``"control"`` is seven characters like ``"2024-01"``, so a length-only test
+            classified it as a month and sent an ensemble member's name down the date
+            path. Shape decides instead.
+        """
+        assert probe_format(text) is None, f"{text!r} should not read as a date label"
+
+    @pytest.mark.parametrize(
+        "text", ["2024", "2024-01", "2024-01-01", "2024-01-01 06:00:00"]
+    )
+    def test_a_date_shaped_string_resolves_a_format(self, text: str):
+        """Every supported precision still resolves to its format."""
+        assert probe_format(text) is not None, f"{text!r} should read as a date label"
+
+    def test_a_non_date_string_is_rejected_by_label_format(self):
+        """``label_format`` refuses it too, so the two agree on what a label is."""
+        with pytest.raises(ValueError, match="not a supported date label"):
+            label_format("control")

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -24,6 +24,7 @@ from pyramids.netcdf._label_select import (
     normalise_label,
     pad_label,
     probe_format,
+    summarise_values,
 )
 
 pytestmark = pytest.mark.core
@@ -369,3 +370,21 @@ class TestNonStandardCalendars:
             2,
             3,
         ]
+
+
+class TestSummariseValues:
+    """How an axis is rendered into an error message."""
+
+    def test_a_short_axis_is_listed_in_full(self):
+        """Everything below the threshold is printed — those values fix the typo."""
+        assert summarise_values([1000.0, 850.0, 500.0]) == "[1000.0, 850.0, 500.0]"
+
+    def test_a_twenty_value_axis_is_still_listed_in_full(self):
+        """The threshold is generous: a monthly or hourly axis stays readable."""
+        assert "..." not in summarise_values(list(range(20)))
+
+    def test_a_long_axis_keeps_both_ends_and_the_count(self):
+        """A 128k-step cloud axis must not become a megabyte of exception text."""
+        rendered = summarise_values(list(range(5000)))
+        assert rendered.startswith("[0, 1, 2, ...")
+        assert rendered.endswith("4997, 4998, 4999] (5000 values)")

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -300,3 +300,48 @@ class TestLabelShapeRecognition:
         """``label_format`` refuses it too, so the two agree on what a label is."""
         with pytest.raises(ValueError, match="not a supported date label"):
             label_format("control")
+
+
+class TestNonStandardCalendars:
+    """A label axis from a non-Gregorian CF calendar selects like any other.
+
+    The decoding itself is cftime's; what is exercised here is that nothing in the
+    matcher assumes Gregorian month lengths — a ``360_day`` axis has a real 30th of
+    February, and ``pad_label``'s day-31 upper bound has to cover it.
+    """
+
+    THIRTY_DAY_FEBRUARY = [
+        "2024-02-28 00:00:00",
+        "2024-02-29 00:00:00",
+        "2024-02-30 00:00:00",
+        "2024-03-01 00:00:00",
+    ]
+
+    def _decode_360(self, fmt: str) -> list[str]:
+        """Decode the synthetic 360-day axis at ``fmt`` by truncating the full labels."""
+        widths = {"%Y": 4, "%Y-%m": 7, "%Y-%m-%d": 10, FULL_FORMAT: 19}
+        return [label[: widths[fmt]] for label in self.THIRTY_DAY_FEBRUARY]
+
+    def test_a_thirtieth_of_february_selects(self):
+        """A date that exists only in a 360-day calendar matches exactly."""
+        assert label_indices(self._decode_360, "2024-02-30") == [2]
+
+    def test_the_month_covers_its_thirtieth_day(self):
+        """A month label covers day 30, which the Gregorian calendar has no February for."""
+        assert label_indices(self._decode_360, "2024-02") == [0, 1, 2]
+
+    def test_a_slice_reaching_day_thirty_includes_it(self):
+        """A range ending on the 30th keeps it — no Gregorian month length is assumed."""
+        assert label_indices(self._decode_360, slice("2024-02-29", "2024-02-30")) == [
+            1,
+            2,
+        ]
+
+    def test_a_month_bound_pads_past_its_last_day(self):
+        """A month as the upper bound covers day 30, which `pad_label` pads past."""
+        assert label_indices(self._decode_360, slice("2024-02", "2024-03")) == [
+            0,
+            1,
+            2,
+            3,
+        ]

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -225,3 +225,23 @@ class TestNearestIndices:
         """An axis of non-numeric coordinates cannot be snapped against."""
         with pytest.raises(ValueError, match="numeric coordinate axis"):
             nearest_indices(["a", "b"], 1.0)
+
+    def test_a_fill_value_in_the_axis_is_never_snapped_to(self):
+        """A NaN coordinate is skipped rather than winning the distance scan.
+
+        Test scenario:
+            NaN compares false against everything, so a plain `min` over the distances
+            used to hand back the fill value's slot — the caller asked for the level
+            nearest 900 and got the hole.
+        """
+        assert nearest_indices([float("nan"), 850.0, 1000.0], 900.0) == [1]
+
+    def test_an_all_fill_axis_is_rejected(self):
+        """An axis with nothing finite to snap to says so instead of guessing."""
+        with pytest.raises(ValueError, match="no finite coordinate"):
+            nearest_indices([float("nan"), float("nan")], 900.0)
+
+    def test_a_non_finite_selector_is_rejected(self):
+        """A NaN or infinite request has no nearest coordinate."""
+        with pytest.raises(ValueError, match="finite selector values"):
+            nearest_indices([1000.0, 850.0], float("nan"))

--- a/tests/netcdf/unit/test_label_select.py
+++ b/tests/netcdf/unit/test_label_select.py
@@ -85,7 +85,7 @@ class TestLabelFormat:
         Test scenario:
             ``"2024-01-01 06:0"`` sits between two supported precisions.
         """
-        with pytest.raises(ValueError, match="Supported precisions"):
+        with pytest.raises(ValueError, match="Write one of"):
             label_format("2024-01-01 06:0")
 
 


### PR DESCRIPTION
# Description

`NetCDF` exposed the time axis through `get_time_values` / `get_time_variable` and derived the spatial axes from
the geotransform, but a **non-spatial, non-time** dimension — `level`, `depth`, `member` — had no accessor at
all. Its values were reachable only through the optional xarray bridge (`to_xarray().coords["level"]`) or by
provoking `sel`'s "Available values" error and parsing the message.

`sel` itself matched a coordinate exactly, so asking for "the level nearest 100 m" meant knowing the axis up
front, and a CF time axis could be selected only by its raw stored offsets — not by the date labels
`get_time_variable` reports. That last one was already documented as working: `docs/reference/netcdf/plot.md`
advertises `Selectors(time="2020-01-01", level=850)`, which found nothing before this change.

This adds the missing accessor and the two selection modes:

- **`get_dimension_values(name)`** reads any dimension's stored coordinates — the same array
  `to_xarray().coords` reports, without the optional extra. A root container reads the coordinate variable; a
  variable subset answers from its own band-dim values, so a `sel`-pinned view reports what it actually holds.
  `get_time_values` is now the time-axis spelling of it rather than a separate path.
- **`sel(..., method="nearest")`** snaps each numeric request to the closest coordinate on its axis. The chosen
  value is readable off the result with `get_dimension_values`. A tie resolves to the smaller coordinate
  whichever way the file stores the axis, so the same physical request answers the same way on an ascending and
  a descending one. It rejects a `slice` and a date label — both already name a range — with an error that says
  what to use instead.
- **Date labels in `sel`**, wherever a CF time axis decodes: a value, a list, or a slice. A label is matched by
  decoding the axis at *that label's* precision, so a partial label matches every step inside the period it
  names (`"2024-01"` takes the month, `"2024-01-01 06:00:00"` takes one step) — xarray's partial-string
  indexing semantics, without adding a dependency. A label is recognised by its shape, so an ensemble member
  named `"control"` stays a stored value. A failed label selection lists the axis' labels rather than its raw
  offsets, so the error speaks the vocabulary the caller used.
- **`Selectors(method=...)`** carries the option into `NetCDF.plot`, applied per dimension: a dim pinned by date
  label stays exact while a numeric one snaps, so "this time step, the nearest level" is one call. Both the
  eager `sel` path and the lazy (`chunks=`) render path resolve a selector through one function,
  `_resolve_selector_indices`, so they cannot drift apart.

The matching primitives live in a new pure module, `src/pyramids/netcdf/_label_select.py` (no pyramids imports,
no new dependencies) — the same shape as the existing `_coord_match.py`.

## Behaviour notes

Unchanged: stored-value selection and the direction-agnostic slice work exactly as before, and an axis whose CF
`units` cannot be parsed has no labels, so a label selector on it finds nothing rather than raising.

Three user-visible changes worth calling out, none of which breaks a call that works today:

- **`get_time_values` answers from a different source on a variable subset.** It now delegates to
  `get_dimension_values`, which prefers the receiver's own band-dimension coordinates — so a subset reports the
  steps that view holds (after a `sel`, the ones it kept) where it previously read the store, or answered
  `None`. On a container nothing changes. The docstring says so.
- **A string-typed coordinate axis now reads instead of raising.** A WRF-style `Times` axis defeated GDAL's
  SWIG `ReadAsArray`, so the container accessor surfaced a raw `RuntimeError`; both the container and the
  variable subset now go through the list-based read `to_xarray` already used, and report the real timestamps.
- **`sel`'s error messages changed.** "Available values" is elided for an axis longer than twenty, so a typo
  against a 128k-step cloud axis no longer produces a megabyte of text; a failed *label* match quotes the
  decoded labels rather than the raw offsets, and says when the axis declares CF units whose values would not
  decode; and a non-date string on a decodable time axis reports "not a supported date label" instead of "No
  bands match". Nothing in the repo matches on those strings.

`docs/change-log.md` carries a whitespace-only commit: the 0.62.0 entry landed with its body padded to a fixed
width, which fails the `trailing-whitespace` pre-commit hook on every pull request (main's own lint run at
`8dacd2b66` was cancelled and never caught it). Applied by the hook itself.

# Issues

- Closes #1125 — no native accessor for a non-spatial coordinate, and label selection cannot snap to nearest

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

113 new tests across six modules, plus the full suite re-run against the change. Fixtures are already in the
repo — `coards__5v__1d4-4d1__y-desc.nc` (levels `[1000, 925, 850, 700]`, `units` that do not parse),
`cf__5v__1d4-4d1__y-asc.nc` (`hours since 2024-01-01`, so its time axis decodes), and
`none__17v__1d1-2d5-3d6-4d5__stag-str.nc` (a WRF-style string `Times` axis).

- `tests/netcdf/unit/test_label_select.py` — the pure primitives: label shape and precision, period-aware slice
  padding, reversed and open bounds, mixed-precision lists, a `360_day` calendar, and nearest (ties across both
  axis directions, out-of-range, dedup, numpy scalars, fill values, the rejected slice / non-numeric cases).
- `tests/netcdf/selection/test_sel_nearest_and_labels.py` — end-to-end on the fixtures: snapped data equals the
  exact selection, the chosen coordinate is readable off the result, labels and raw offsets read the same
  plane, `get_time_variable`'s round-trip at both precisions, every shape of undecodable coordinate value
  (`_FillValue`, infinity, NaN) degrading rather than aborting, the mixed-vocabulary and elided-message
  contracts, and that the axis is decoded once per selection rather than four times.
- `tests/netcdf/structure/test_dimension_values.py` — the accessor on a container and on a subset, before and
  after a `sel`, the storage-order contract on a y-ascending and a y-descending file, the string-typed axis, and
  `get_time_values` keeping its contract now that it delegates.
- `tests/netcdf/plot/` — `Selectors.method` through `NetCDF.plot`, eager and `chunks=`, including a decoded CF
  label and a snapped level in the same call.

Reproduce:

```bash
pixi run -e dev pytest tests -m "not plot"   # 11702 passed, 89 skipped
pixi run -e dev pytest tests -m plot         # 448 passed, 1 xfailed
```

- [x] Test A — full suite (`-m "not plot"`): 11702 passed, 89 skipped.
- [x] Test B — plot suite: 448 passed, 1 xfailed. Doctests on the five touched modules: 54 passed, 11 skipped.
      ruff 0.15.22 check + format clean, mypy clean, the full pre-commit hook set green, SonarCloud 0 open
      issues. Every executable line the branch adds is covered (204/204); `_label_select.py` is at 100 % line
      and branch.

# Checklist:

- [ ] updated version number in pyproject.toml. — commitizen owns the version; not bumped by hand.
- [ ] added changes to History.rst. — the changelog is commitizen-generated.
- [ ] updated the latest version in README file. — same, handled by the release job.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — a new "Dimension coordinates and selection" section in
      `docs/reference/netcdf/index.md`, and `docs/reference/netcdf/plot.md` now describes `Selectors.method` and
      the two `time=` vocabularies (the example it already showed).
